### PR TITLE
MSRV: document and support 1.36.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,17 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["beta", "1.36.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt
       - name: Rustfmt check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## [0.3.0] — 2021-03-29
+
+-   Explicitly support Rust 1.36.0 (and potentially older; #10)
+-   Support `no_std` (#10)
+-   Fix rounding for `floor` on negative values (#10)
+
 ## [0.2.0] — 2021-03-20
 
 -   Add feature flags controlling assert behaviour

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ keywords = ["cast", "into", "from", "conversion"]
 repository = "https://github.com/kas-gui/easy-cast"
 
 [features]
+default = ["std"]
+
+# Without std, float conversions are disabled
+std = []
+
 # Note: assertions are always used in debug builds; these only affect release builds:
 
 # Always use all assertions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/kas-gui/easy-cast"
 [features]
 default = ["std"]
 
-# Without std, float conversions are disabled
+# Without std, float conversions are disabled (unless libm is used)
 std = []
 
 # Note: assertions are always used in debug builds; these only affect release builds:
@@ -29,3 +29,8 @@ assert_non_neg = []
 
 # Always assert value is within target type's range
 assert_range = []
+
+[dependencies.libm]
+# libm may be used instead of std to provide float conversions
+version = "0.2.1"
+optional = true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ If the `always_assert` feature flag is set, assertions will be turned on in
 all builds. Some additional feature flags are available for finer-grained
 control (see [Cargo.toml](Cargo.toml)).
 
+## MSRV
+
+The Minumum Supported Rust Version is 1.36.0 (older versions may work but are
+untested).
+
 
 Copyright and Licence
 -------

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ untested).
 
 By default, `std` support is required. With default features disabled `no_std`
 is supported, but the `ConvFloat` and `CastFloat` traits are unavailable.
+Enabling the `libm` feature will re-enable these traits.
 
 
 Copyright and Licence

--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ If the `always_assert` feature flag is set, assertions will be turned on in
 all builds. Some additional feature flags are available for finer-grained
 control (see [Cargo.toml](Cargo.toml)).
 
-## MSRV
+## MSRV and no_std
 
 The Minumum Supported Rust Version is 1.36.0 (older versions may work but are
 untested).
+
+By default, `std` support is required. With default features disabled `no_std`
+is supported, but the `ConvFloat` and `CastFloat` traits are unavailable.
 
 
 Copyright and Licence

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 //! all builds. Some additional feature flags are available for finer-grained
 //! control (see `Cargo.toml`).
 
+#![deny(missing_docs)]
+
 use std::mem::size_of;
 
 /// Like [`From`], but supporting potentially-fallible conversions
@@ -51,6 +53,7 @@ use std::mem::size_of;
 ///
 /// [`From`]: std::convert::From
 pub trait Conv<T> {
+    /// Convert from `T` to `Self` (see trait doc)
     fn conv(v: T) -> Self;
 }
 
@@ -381,6 +384,7 @@ impl ConvFloat<f32> for u128 {
 
 /// Like [`Into`], but for [`Conv`]
 pub trait Cast<T> {
+    /// Cast from `Self` to `T` (see trait doc)
     fn cast(self) -> T;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 use core::mem::size_of;
 
@@ -298,6 +299,7 @@ impl_via_digits_check!(usize: f32, f64);
 /// If the source value is out-of-range or not-a-number then the conversion must
 /// fail with a panic.
 #[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 pub trait ConvFloat<T> {
     /// Convert to the nearest integer
     ///
@@ -404,6 +406,7 @@ impl<S, T: Conv<S>> Cast<T> for S {
 
 /// Like [`Into`], but for [`ConvFloat`]
 #[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 pub trait CastFloat<T> {
     /// Cast to the nearest integer
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,7 @@ macro_rules! impl_float {
             }
             #[inline]
             fn conv_floor(x: $x) -> $y {
+                let x = x.floor();
                 if cfg!(any(debug_assertions, feature = "assert_float")) {
                     const LBOUND: $x = std::$y::MIN as $x;
                     const UBOUND: $x = std::$y::MAX as $x + 1.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,17 +111,17 @@ impl_via_as_neg_check!(i128: u128);
 
 // Assumption: $y::MAX is representable as $x
 macro_rules! impl_via_as_max_check {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 #[cfg(any(debug_assertions, feature = "assert_range"))]
-                assert!(x <= <$y>::MAX as $x);
+                assert!(x <= std::$y::MAX as $x);
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_via_as_max_check!($x: $y);
         impl_via_as_max_check!($x: $($yy),+);
     };
@@ -136,17 +136,17 @@ impl_via_as_max_check!(u128: u8, u16, u32, u64);
 
 // Assumption: $y::MAX and $y::MIN are representable as $x
 macro_rules! impl_via_as_range_check {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 #[cfg(any(debug_assertions, feature = "assert_range"))]
-                assert!(<$y>::MIN as $x <= x && x <= <$y>::MAX as $x);
+                assert!(std::$y::MIN as $x <= x && x <= std::$y::MAX as $x);
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_via_as_range_check!($x: $y);
         impl_via_as_range_check!($x: $($yy),+);
     };
@@ -158,22 +158,22 @@ impl_via_as_range_check!(i64: i8, i16, i32, u8, u16, u32);
 impl_via_as_range_check!(i128: i8, i16, i32, i64, u8, u16, u32, u64);
 
 macro_rules! impl_int_signed_dest {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 if size_of::<$x>() == size_of::<$y>() {
                     #[cfg(any(debug_assertions, feature = "assert_range"))]
-                    assert!(x <= <$y>::MAX as $x);
+                    assert!(x <= std::$y::MAX as $x);
                 } else if size_of::<$x>() > size_of::<$y>() {
                     #[cfg(any(debug_assertions, feature = "assert_range"))]
-                    assert!(<$y>::MIN as $x <= x && x <= <$y>::MAX as $x);
+                    assert!(std::$y::MIN as $x <= x && x <= std::$y::MAX as $x);
                 }
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_int_signed_dest!($x: $y);
         impl_int_signed_dest!($x: $($yy),+);
     };
@@ -193,7 +193,7 @@ impl_int_signed_dest!(isize: i8, i16, i32, i64, i128);
 impl_int_signed_dest!(usize: i8, i16, i32, i64, i128, isize);
 
 macro_rules! impl_int_signed_to_unsigned {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
@@ -201,13 +201,13 @@ macro_rules! impl_int_signed_to_unsigned {
                 assert!(x >= 0);
                 if size_of::<$x>() > size_of::<$y>() {
                     #[cfg(any(debug_assertions, feature = "assert_range"))]
-                    assert!(x <= <$y>::MAX as $x);
+                    assert!(x <= std::$y::MAX as $x);
                 }
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_int_signed_to_unsigned!($x: $y);
         impl_int_signed_to_unsigned!($x: $($yy),+);
     };
@@ -221,19 +221,19 @@ impl_int_signed_to_unsigned!(i128: usize);
 impl_int_signed_to_unsigned!(isize: u8, u16, u32, u64, u128, usize);
 
 macro_rules! impl_int_unsigned_to_unsigned {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 if size_of::<$x>() > size_of::<$y>() {
                     #[cfg(any(debug_assertions, feature = "assert_range"))]
-                    assert!(x <= <$y>::MAX as $x);
+                    assert!(x <= std::$y::MAX as $x);
                 }
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_int_unsigned_to_unsigned!($x: $y);
         impl_int_unsigned_to_unsigned!($x: $($yy),+);
     };
@@ -257,21 +257,21 @@ impl Conv<f64> for f32 {
 }
 
 macro_rules! impl_via_digits_check {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
                     let src_ty_bits = u32::conv(size_of::<$x>() * 8);
                     let src_digits = src_ty_bits - (x.leading_zeros() + x.trailing_zeros());
-                    let dst_digits = <$y>::MANTISSA_DIGITS;
+                    let dst_digits = std::$y::MANTISSA_DIGITS;
                     assert!(src_digits <= dst_digits);
                 }
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_via_digits_check!($x: $y);
         impl_via_digits_check!($x: $($yy),+);
     };
@@ -309,15 +309,15 @@ pub trait ConvFloat<T> {
 }
 
 macro_rules! impl_float {
-    ($x:ty: $y:ty) => {
+    ($x:ty: $y:tt) => {
         impl ConvFloat<$x> for $y {
             #[inline]
             fn conv_nearest(x: $x) -> $y {
                 let x = x.round();
                 if cfg!(any(debug_assertions, feature = "assert_float")) {
                     // Tested: these limits work for $x=f32 and all $y except u128
-                    const LBOUND: $x = <$y>::MIN as $x;
-                    const UBOUND: $x = <$y>::MAX as $x + 1.0;
+                    const LBOUND: $x = std::$y::MIN as $x;
+                    const UBOUND: $x = std::$y::MAX as $x + 1.0;
                     assert!(x >= LBOUND && x < UBOUND);
                 }
                 x as $y
@@ -325,8 +325,8 @@ macro_rules! impl_float {
             #[inline]
             fn conv_floor(x: $x) -> $y {
                 if cfg!(any(debug_assertions, feature = "assert_float")) {
-                    const LBOUND: $x = <$y>::MIN as $x;
-                    const UBOUND: $x = <$y>::MAX as $x + 1.0;
+                    const LBOUND: $x = std::$y::MIN as $x;
+                    const UBOUND: $x = std::$y::MAX as $x + 1.0;
                     assert!(x >= LBOUND && x < UBOUND);
                 }
                 x as $y
@@ -335,15 +335,15 @@ macro_rules! impl_float {
             fn conv_ceil(x: $x) -> $y {
                 let x = x.ceil();
                 if cfg!(any(debug_assertions, feature = "assert_float")) {
-                    const LBOUND: $x = <$y>::MIN as $x;
-                    const UBOUND: $x = <$y>::MAX as $x + 1.0;
+                    const LBOUND: $x = std::$y::MIN as $x;
+                    const UBOUND: $x = std::$y::MAX as $x + 1.0;
                     assert!(x >= LBOUND && x < UBOUND);
                 }
                 x as $y
             }
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_float!($x: $y);
         impl_float!($x: $($yy),+);
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,5 +21,5 @@ fn float_casts() {
 #[test]
 #[should_panic]
 fn u32_max_f32() {
-    f32::conv(u32::MAX);
+    f32::conv(std::u32::MAX);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,6 +17,7 @@ fn float_casts() {
     assert_eq!(x, 14);
     assert_eq!(u8::conv_floor(13.8f64), 13);
     assert_eq!(u32::conv_ceil(13.1f32), 14);
+    assert_eq!(i64::conv_floor(-3168565.13), -3168566);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,6 +10,7 @@ fn int_casts() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn float_casts() {
     assert_eq!(u64::conv_nearest(13.2f32), 13);
     let x: i128 = 13.5f32.cast_nearest();
@@ -21,5 +22,5 @@ fn float_casts() {
 #[test]
 #[should_panic]
 fn u32_max_f32() {
-    f32::conv(std::u32::MAX);
+    f32::conv(core::u32::MAX);
 }


### PR DESCRIPTION
Closes #9.

@vks I don't see *any* `no_std` tests for `rand_distr`. Maybe we should rectify that. This will still cause problems with `average` though, which claims to work without `std`.

I guess the easiest solution is to feature-gate float conversions in this crate.