### PR TITLE
Add try_conv and try_cast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,20 +7,16 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
-    name: Test
+  fmt-and-test:
+    name: Test and check formatting
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: ["beta", "1.36.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: beta
           override: true
           components: rustfmt
       - name: Rustfmt check
@@ -28,6 +24,24 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+      - name: Test
+        run: |
+          cargo test
+          cargo test --all-features
+          cargo test --no-default-features
+          cargo test --no-default-features --features libm
+
+  test:
+    name: Test MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.32.0"
+          override: true
       - name: Test
         run: |
           cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,8 @@ jobs:
           command: fmt
           args: --all -- --check
       - name: Test
-        run: cargo test --all-features
+        run: |
+          cargo test
+          cargo test --all-features
+          cargo test --no-default-features
+          cargo test --no-default-features --features libm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 -   Add `try_conv` and `try_cast` methods (#12)
 -   Add `try_conv_nearest` etc. (#12)
+-   Removed `Conv<f64> for f32` (#12)
+-   Replaced `assert_range` and `assert_non_neg` with `assert_int` (#12)
 
 ## [0.3.0] — 2021-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-## [0.4.0] — 2021-04-??
+## [0.4.0] — 2021-04-01
 
--   Add `try_conv` and `try_cast` methods
+-   Add `try_conv` and `try_cast` methods (#12)
+-   Add `try_conv_nearest` etc. (#12)
 
 ## [0.3.0] — 2021-03-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## [0.4.0] — 2021-04-??
+
+-   Add `try_conv` and `try_cast` methods
+
 ## [0.3.0] — 2021-03-29
 
 -   Add `conv_trunc` / `cast_trunc` (#11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 -   Add `try_conv_nearest` etc. (#12)
 -   Removed `Conv<f64> for f32` (#12)
 -   Replaced `assert_range` and `assert_non_neg` with `assert_int` (#12)
+-   MSRV is 1.32.0 (#12)
 
 ## [0.3.0] — 2021-03-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,13 @@ std = []
 # Note: assertions are always used in debug builds; these only affect release builds:
 
 # Always use all assertions
-always_assert = ["assert_float", "assert_non_neg", "assert_range"]
+always_assert = ["assert_float", "assert_int"]
 
 # Always assert when converting from floating-point types
 assert_float = []
 
-# Always assert source is not neg when converting to unsigned
-assert_non_neg = []
-
-# Always assert value is within target type's range
-assert_range = []
+# Always assert when converting from integer types
+assert_int = []
 
 [dependencies.libm]
 # libm may be used instead of std to provide float conversions

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ control (see [Cargo.toml](Cargo.toml)).
 
 ## MSRV and no_std
 
-The Minumum Supported Rust Version is 1.36.0 (older versions may work but are
-untested).
+The Minumum Supported Rust Version is 1.32.0 (first release of Edition 2018).
 
 By default, `std` support is required. With default features disabled `no_std`
 is supported, but the `ConvFloat` and `CastFloat` traits are unavailable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,9 +673,11 @@ pub trait Cast<T> {
 }
 
 impl<S, T: Conv<S>> Cast<T> for S {
+    #[inline]
     fn cast(self) -> T {
         T::conv(self)
     }
+    #[inline]
     fn try_cast(self) -> Result<T, Error> {
         T::try_conv(self)
     }
@@ -701,20 +703,58 @@ pub trait CastFloat<T> {
     ///
     /// Returns the smallest integer greater than or equal to `self`.
     fn cast_ceil(self) -> T;
+
+    /// Try converting to integer with truncation
+    ///
+    /// Rounds towards zero (same as `as`).
+    fn try_cast_trunc(self) -> Result<T, Error>;
+    /// Try converting to the nearest integer
+    ///
+    /// Half-way cases are rounded away from `0`.
+    fn try_cast_nearest(self) -> Result<T, Error>;
+    /// Try converting the floor to an integer
+    ///
+    /// Returns the largest integer less than or equal to `x`.
+    fn try_cast_floor(self) -> Result<T, Error>;
+    /// Try convert the ceiling to an integer
+    ///
+    /// Returns the smallest integer greater than or equal to `x`.
+    fn try_cast_ceil(self) -> Result<T, Error>;
 }
 
 #[cfg(any(feature = "std", feature = "libm"))]
 impl<S, T: ConvFloat<S>> CastFloat<T> for S {
+    #[inline]
     fn cast_trunc(self) -> T {
         T::conv_trunc(self)
     }
+    #[inline]
     fn cast_nearest(self) -> T {
         T::conv_nearest(self)
     }
+    #[inline]
     fn cast_floor(self) -> T {
         T::conv_floor(self)
     }
+    #[inline]
     fn cast_ceil(self) -> T {
         T::conv_ceil(self)
+    }
+
+    #[inline]
+    fn try_cast_trunc(self) -> Result<T, Error> {
+        T::try_conv_trunc(self)
+    }
+    #[inline]
+    fn try_cast_nearest(self) -> Result<T, Error> {
+        T::try_conv_nearest(self)
+    }
+    #[inline]
+    fn try_cast_floor(self) -> Result<T, Error> {
+        T::try_conv_floor(self)
+    }
+    #[inline]
+    fn try_cast_ceil(self) -> Result<T, Error> {
+        T::try_conv_ceil(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "easy-cast conversion error: {}",
+            "cast conversion: {}",
             match self {
                 Error::Range => "source value not in target range",
                 Error::Inexact => "loss of precision or range error",
@@ -381,7 +381,7 @@ macro_rules! impl_via_digits_check {
             #[inline]
             fn conv(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    Self::try_conv(x).expect("inexact int→float conversion")
+                    Self::try_conv(x).expect("int-to-float conversion: inexact")
                 } else {
                     x as $y
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,25 +378,6 @@ impl_int_unsigned_to_unsigned!(u64: usize);
 impl_int_unsigned_to_unsigned!(u128: usize);
 impl_int_unsigned_to_unsigned!(usize: u8, u16, u32, u64, u128);
 
-impl Conv<f64> for f32 {
-    #[inline]
-    fn conv(x: f64) -> f32 {
-        let y = x as f32;
-        #[cfg(any(debug_assertions, feature = "assert_float"))]
-        assert_eq!(x, y as f64);
-        y
-    }
-    #[inline]
-    fn try_conv(x: f64) -> Result<Self, Error> {
-        let y = x as f32;
-        if x == y as f64 {
-            Ok(y)
-        } else {
-            Err(Error::Inexact)
-        }
-    }
-}
-
 macro_rules! impl_via_digits_check {
     ($x:ty: $y:tt) => {
         impl Conv<$x> for $y {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ macro_rules! impl_via_as_neg_check {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
-                #[cfg(any(debug_assertions, feature = "assert_non_neg"))]
+                #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(x >= 0);
                 x as $y
             }
@@ -193,7 +193,7 @@ macro_rules! impl_via_as_max_check {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
-                #[cfg(any(debug_assertions, feature = "assert_range"))]
+                #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(x <= core::$y::MAX as $x);
                 x as $y
             }
@@ -226,7 +226,7 @@ macro_rules! impl_via_as_range_check {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
-                #[cfg(any(debug_assertions, feature = "assert_range"))]
+                #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(core::$y::MIN as $x <= x && x <= core::$y::MAX as $x);
                 x as $y
             }
@@ -257,10 +257,10 @@ macro_rules! impl_int_signed_dest {
             #[inline]
             fn conv(x: $x) -> $y {
                 if size_of::<$x>() == size_of::<$y>() {
-                    #[cfg(any(debug_assertions, feature = "assert_range"))]
+                    #[cfg(any(debug_assertions, feature = "assert_int"))]
                     assert!(x <= core::$y::MAX as $x);
                 } else if size_of::<$x>() > size_of::<$y>() {
-                    #[cfg(any(debug_assertions, feature = "assert_range"))]
+                    #[cfg(any(debug_assertions, feature = "assert_int"))]
                     assert!(core::$y::MIN as $x <= x && x <= core::$y::MAX as $x);
                 }
                 x as $y
@@ -306,11 +306,12 @@ macro_rules! impl_int_signed_to_unsigned {
         impl Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
-                #[cfg(any(debug_assertions, feature = "assert_non_neg"))]
-                assert!(x >= 0);
                 if size_of::<$x>() > size_of::<$y>() {
-                    #[cfg(any(debug_assertions, feature = "assert_range"))]
-                    assert!(x <= core::$y::MAX as $x);
+                    #[cfg(any(debug_assertions, feature = "assert_int"))]
+                    assert!(x >= 0 && x <= core::$y::MAX as $x);
+                } else {
+                    #[cfg(any(debug_assertions, feature = "assert_int"))]
+                    assert!(x >= 0);
                 }
                 x as $y
             }
@@ -346,7 +347,7 @@ macro_rules! impl_int_unsigned_to_unsigned {
             #[inline]
             fn conv(x: $x) -> $y {
                 if size_of::<$x>() > size_of::<$y>() {
-                    #[cfg(any(debug_assertions, feature = "assert_range"))]
+                    #[cfg(any(debug_assertions, feature = "assert_int"))]
                     assert!(x <= core::$y::MAX as $x);
                 }
                 x as $y

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,6 +32,7 @@ fn float_trunc() {
 
 #[test]
 #[should_panic]
+#[cfg(any(feature = "std", feature = "libm"))]
 fn float_trunc_fail1() {
     i16::conv_trunc(32768.0f32);
 }


### PR DESCRIPTION
Closes #4. I see two potential uses for these additional conversions (though didn't yet need them myself):

1. If the conversion is fallible, and failure should be handled at run-time.
2. If the conversion may be fallible and we want to ensure a check occurs (without using the `always_assert` feature).

~~TODO: float conversions.~~ Code share with `conv` is minimal and probably that's for the best.

I'll just leave this here for now. If @BartMassey or @vks or anyone else wishes to comment, please do.