### PR TITLE
Re-introduce impl_int_generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,7 @@ impl_via_as_range_check!(i128: i8, i16, i32, i64, u8, u16, u32, u64);
 macro_rules! impl_int_generic {
     ($x:tt: $y:tt) => {
         impl Conv<$x> for $y {
+            #[allow(unused_comparisons)]
             #[inline]
             fn conv(x: $x) -> $y {
                 let src_is_signed = core::$x::MIN != 0;
@@ -281,6 +282,7 @@ macro_rules! impl_int_generic {
                 }
                 x as $y
             }
+            #[allow(unused_comparisons)]
             #[inline]
             fn try_conv(x: $x) -> Result<Self, Error> {
                 let src_is_signed = core::$x::MIN != 0;


### PR DESCRIPTION
This macro replaces three, and could potentially replace more. All but the last conditional can be evaluated at compile-time, thus it shouldn't be any slower, and less code implies less places for bugs to hide.

Unfortunately I cannot squelch some of the warnings (even though these paths should not be evaluated for the types in question):
```
warning: comparison is useless due to type limits
   --> src/lib.rs:263:46
    |
263 |                     assert!(dst_is_signed || x >= 0);
    |                                              ^^^^^^
...
336 | impl_int_generic!(usize: u8, u16, u32, u64, u128);
    | -------------------------------------------------- in this macro invocation
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: comparison is useless due to type limits
   --> src/lib.rs:268:33
    |
268 |                         assert!(x >= 0);
    |                                 ^^^^^^
...
336 | impl_int_generic!(usize: u8, u16, u32, u64, u128);
    | -------------------------------------------------- in this macro invocation
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: comparison is useless due to type limits
   --> src/lib.rs:285:41
    |
285 |                     if dst_is_signed || x >= 0 {
    |                                         ^^^^^^
...
336 | impl_int_generic!(usize: u8, u16, u32, u64, u128);
    | -------------------------------------------------- in this macro invocation
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: comparison is useless due to type limits
   --> src/lib.rs:294:28
    |
294 |                         if x >= 0 {
    |                            ^^^^^^
...
336 | impl_int_generic!(usize: u8, u16, u32, u64, u128);
    | -------------------------------------------------- in this macro invocation
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```