### PR TITLE
Better error messages for asserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## [0.4.3] — 2021-04-12
+
+-   Unify some macros via `impl_int_generic` (#16)
+-   Improve error messages in asserts (#17)
+
 ## [0.4.2] — 2021-04-03
 
 -   Fix `i16::conv(1usize)` (#15)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ macro_rules! impl_via_as_neg_check {
                 #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(
                     x >= 0,
-                    "cast x: {} to {}: expected x > 0, found x = {}",
+                    "cast x: {} to {}: expected x >= 0, found x = {}",
                     stringify!($x), stringify!($y), x
                 );
                 x as $y
@@ -276,7 +276,7 @@ macro_rules! impl_int_generic {
                         #[cfg(any(debug_assertions, feature = "assert_int"))]
                         assert!(
                             x >= 0,
-                            "cast x: {} to {}: expected x > 0, found x = {}",
+                            "cast x: {} to {}: expected x >= 0, found x = {}",
                             stringify!($x), stringify!($y), x
                         );
                     }
@@ -292,7 +292,7 @@ macro_rules! impl_int_generic {
                         #[cfg(any(debug_assertions, feature = "assert_int"))]
                         assert!(
                             x >= 0,
-                            "cast x: {} to {}: expected x > 0, found x = {}",
+                            "cast x: {} to {}: expected x >= 0, found x = {}",
                             stringify!($x), stringify!($y), x
                         );
                     }


### PR DESCRIPTION
I got a little fed up with it not being obvious *why* an assert triggered, hence this PR.

Examples:
```
thread 'int_casts' panicked at 'cast x: i8 to u8: expected x > 0, found x = -3'
thread 'int_casts' panicked at 'cast x: u16 to i8: expected x <= 127, found x = 256'
thread 'int_casts' panicked at 'cast x: isize to i8: expected -128 <= x <= 127, found x = 256'
thread 'float_casts' panicked at 'cast x: u32 to f32: inexact for x = 4294967295'
thread 'float_casts' panicked at 'cast x: f64 to i8 (nearest): range error for x = 127.5'
```

My only concern is that the extra formatting machinery may have some cost. Then again, the design of the library allows removing these "fuses" in release builds if this is deemed appropriate.

@vks thoughts?