### PR TITLE
ConvApprox/CastApprox; tuple + array support; doc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.32.0"
+          toolchain: "1.53.0"
           override: true
       - name: Test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## [0.5.0] — unreleased
+
+-   Add `ConvApprox` and `CastApprox`
+-   Support `Conv` and `ConvFloat` for arrays and tuples
+-   Remove `impl<T> Conv<T> for T`
+
 ## [0.4.4] — 2021-04-12
 
 -   Fix negative int to float digits check (#18)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ control (see [Cargo.toml](Cargo.toml)).
 
 ## MSRV and no_std
 
-The Minumum Supported Rust Version is 1.32.0 (first release of Edition 2018).
+The Minumum Supported Rust Version is 1.53.0 (`IntoIterator for [T; N]`).
 
 By default, `std` support is required. With default features disabled `no_std`
 is supported, but the `ConvFloat` and `CastFloat` traits are unavailable.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ If the `always_assert` feature flag is set, assertions will be turned on in
 all builds. Some additional feature flags are available for finer-grained
 control (see `Cargo.toml`).
 
+### Performance
+
+Performance is "good enough that it hasn't been a concern".
+
+In debug builds and when `always_assert` is enabled, the priority is testing
+but overhead should be small.
+
+In release builds without `always_assert`, `conv*` methods should reduce to
+`x as T` (with necessary additions for rounding).
+
 ### no_std support
 
 When the crate's default features are disabled (and `std` is not enabled)

--- a/README.md
+++ b/README.md
@@ -6,38 +6,54 @@ Easy-cast
 
 Type conversion, success expected
 
-This library is written to make numeric type conversions easy. Such
-conversions usually fall into one of the following cases:
+This library exists to make fallible numeric type conversions easy, without
+resorting to the `as` keyword.
 
--   the conversion must preserve values exactly (use [`From`] or [`Into`]
-    or [`Conv`] or [`Cast`])
--   the conversion is expected to preserve values exactly, though this is
-    not ensured by the types in question (use [`Conv`] or [`Cast`])
--   the conversion could fail and must be checked at run-time (use
-    [`TryFrom`] or [`TryInto`] or [`Conv::try_conv`] or [`Cast::try_cast`])
--   the conversion is from floating point values to integers and should
-    round to the "nearest" integer (use [`ConvFloat`] or [`CastFloat`])
--   the conversion is from `f32` to `f64` or vice-versa; in this case use of
-    `as f32` / `as f64` is likely acceptable since `f32` has special
-    representations for non-finite values and conversion to `f64` is exact
--   truncating conversion (modular arithmetic) is desired; in this case `as`
-    probably does exactly what you want
--   saturating conversion is desired (less common; not supported here)
+-   [`Conv`] is like [`From`], but supports fallible conversions
+-   [`Cast`] is to [`Conv`] what [`Into`] is to [`From`]
+-   [`ConvApprox`] and [`CastApprox`] support fallible, approximate conversion
+-   [`ConvFloat`] and [`CastFloat`] are similar, providing precise control over rounding
 
 If you are wondering "why not just use `as`", there are a few reasons:
 
--   integer conversions may silently truncate
--   integer conversions to/from signed types silently reinterpret
+-   integer conversions may silently truncate or sign-extend which does not
+    preserve value
 -   prior to Rust 1.45.0 float-to-int conversions were not fully defined;
     since this version they use saturating conversion (NaN converts to 0)
 -   you want some assurance (at least in debug builds) that the conversion
-    will preserve values correctly without having to proof-read code
+    will preserve values correctly
 
-When should you *not* use this library?
+Why might you *not* want to use this library?
 
--   Only numeric conversions are supported
--   Conversions from floats do not provide fine control of rounding modes
--   This library has not been thoroughly tested correctness
+-   You want saturating / truncating / other non-value-preserving conversion
+-   You want to convert non-numeric types ([`From`] supports a lot more
+    conversions than [`Conv`] does)!
+-   You want a thoroughly tested library (we're not quite there yet)
+
+### Error handling
+
+All traits support two methods:
+
+-   `try_*` methods return a `Result` and always fail if the correct
+    conversion is not possible
+-   other methods may panic or return incorrect results
+
+In debug builds, methods not returning `Result` must panic on failure. As
+with the overflow checks on Rust's standard integer arithmetic, this is
+considered a tool for finding logic errors. In release builds, these methods
+are permitted to return defined but incorrect results similar to the `as`
+keyword.
+
+If the `always_assert` feature flag is set, assertions will be turned on in
+all builds. Some additional feature flags are available for finer-grained
+control (see `Cargo.toml`).
+
+### no_std support
+
+When the crate's default features are disabled (and `std` is not enabled)
+then the library supports `no_std`. In this case, [`ConvFloat`] and
+[`CastFloat`] are only available if the `libm` optional dependency is
+enabled.
 
 [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
 [`Into`]: https://doc.rust-lang.org/stable/std/convert/trait.Into.html
@@ -49,16 +65,6 @@ When should you *not* use this library?
 [`Conv::try_cast`]: https://docs.rs/easy-cast/latest/easy_cast/trait.Conv.html#tymethod.try_cast
 [`ConvFloat`]: https://docs.rs/easy-cast/latest/easy_cast/trait.ConvFloat.html
 [`CastFloat`]: https://docs.rs/easy-cast/latest/easy_cast/trait.CastFloat.html
-
-## Assertions
-
-All type conversions which are potentially fallible assert on failure in
-debug builds. In release builds assertions may be omitted, thus making
-incorrect conversions possible.
-
-If the `always_assert` feature flag is set, assertions will be turned on in
-all builds. Some additional feature flags are available for finer-grained
-control (see [Cargo.toml](Cargo.toml)).
 
 ## MSRV and no_std
 

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -47,6 +47,14 @@ impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
         }
         Ok(tt)
     }
+    #[inline]
+    fn conv(ss: [S; N]) -> Self {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::conv(s);
+        }
+        tt
+    }
 }
 
 impl Conv<()> for () {
@@ -54,11 +62,19 @@ impl Conv<()> for () {
     fn try_conv(_: ()) -> Result<Self, Error> {
         Ok(())
     }
+    #[inline]
+    fn conv(_: ()) -> Self {
+        ()
+    }
 }
 impl<S0, T0: Conv<S0>> Conv<(S0,)> for (T0,) {
     #[inline]
     fn try_conv(ss: (S0,)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?,))
+    }
+    #[inline]
+    fn conv(ss: (S0,)) -> Self {
+        (ss.0.cast(),)
     }
 }
 impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
@@ -66,11 +82,19 @@ impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
     fn try_conv(ss: (S0, S1)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?, ss.1.try_cast()?))
     }
+    #[inline]
+    fn conv(ss: (S0, S1)) -> Self {
+        (ss.0.cast(), ss.1.cast())
+    }
 }
 impl<S0, S1, S2, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>> Conv<(S0, S1, S2)> for (T0, T1, T2) {
     #[inline]
     fn try_conv(ss: (S0, S1, S2)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?, ss.1.try_cast()?, ss.2.try_cast()?))
+    }
+    #[inline]
+    fn conv(ss: (S0, S1, S2)) -> Self {
+        (ss.0.cast(), ss.1.cast(), ss.2.cast())
     }
 }
 impl<S0, S1, S2, S3, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>> Conv<(S0, S1, S2, S3)>
@@ -85,6 +109,10 @@ impl<S0, S1, S2, S3, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>> Con
             ss.3.try_cast()?,
         ))
     }
+    #[inline]
+    fn conv(ss: (S0, S1, S2, S3)) -> Self {
+        (ss.0.cast(), ss.1.cast(), ss.2.cast(), ss.3.cast())
+    }
 }
 impl<S0, S1, S2, S3, S4, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>, T4: Conv<S4>>
     Conv<(S0, S1, S2, S3, S4)> for (T0, T1, T2, T3, T4)
@@ -98,6 +126,16 @@ impl<S0, S1, S2, S3, S4, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>,
             ss.3.try_cast()?,
             ss.4.try_cast()?,
         ))
+    }
+    #[inline]
+    fn conv(ss: (S0, S1, S2, S3, S4)) -> Self {
+        (
+            ss.0.cast(),
+            ss.1.cast(),
+            ss.2.cast(),
+            ss.3.cast(),
+            ss.4.cast(),
+        )
     }
 }
 impl<S0, S1, S2, S3, S4, S5, T0, T1, T2, T3, T4, T5> Conv<(S0, S1, S2, S3, S4, S5)>
@@ -120,5 +158,16 @@ where
             ss.4.try_cast()?,
             ss.5.try_cast()?,
         ))
+    }
+    #[inline]
+    fn conv(ss: (S0, S1, S2, S3, S4, S5)) -> Self {
+        (
+            ss.0.cast(),
+            ss.1.cast(),
+            ss.2.cast(),
+            ss.3.cast(),
+            ss.4.cast(),
+            ss.5.cast(),
+        )
     }
 }

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -48,3 +48,77 @@ impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
         Ok(tt)
     }
 }
+
+impl Conv<()> for () {
+    #[inline]
+    fn try_conv(_: ()) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+impl<S0, T0: Conv<S0>> Conv<(S0,)> for (T0,) {
+    #[inline]
+    fn try_conv(ss: (S0,)) -> Result<Self, Error> {
+        Ok((ss.0.try_cast()?,))
+    }
+}
+impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
+    #[inline]
+    fn try_conv(ss: (S0, S1)) -> Result<Self, Error> {
+        Ok((ss.0.try_cast()?, ss.1.try_cast()?))
+    }
+}
+impl<S0, S1, S2, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>> Conv<(S0, S1, S2)> for (T0, T1, T2) {
+    #[inline]
+    fn try_conv(ss: (S0, S1, S2)) -> Result<Self, Error> {
+        Ok((ss.0.try_cast()?, ss.1.try_cast()?, ss.2.try_cast()?))
+    }
+}
+impl<S0, S1, S2, S3, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>> Conv<(S0, S1, S2, S3)>
+    for (T0, T1, T2, T3)
+{
+    #[inline]
+    fn try_conv(ss: (S0, S1, S2, S3)) -> Result<Self, Error> {
+        Ok((
+            ss.0.try_cast()?,
+            ss.1.try_cast()?,
+            ss.2.try_cast()?,
+            ss.3.try_cast()?,
+        ))
+    }
+}
+impl<S0, S1, S2, S3, S4, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>, T4: Conv<S4>>
+    Conv<(S0, S1, S2, S3, S4)> for (T0, T1, T2, T3, T4)
+{
+    #[inline]
+    fn try_conv(ss: (S0, S1, S2, S3, S4)) -> Result<Self, Error> {
+        Ok((
+            ss.0.try_cast()?,
+            ss.1.try_cast()?,
+            ss.2.try_cast()?,
+            ss.3.try_cast()?,
+            ss.4.try_cast()?,
+        ))
+    }
+}
+impl<S0, S1, S2, S3, S4, S5, T0, T1, T2, T3, T4, T5> Conv<(S0, S1, S2, S3, S4, S5)>
+    for (T0, T1, T2, T3, T4, T5)
+where
+    T0: Conv<S0>,
+    T1: Conv<S1>,
+    T2: Conv<S2>,
+    T3: Conv<S3>,
+    T4: Conv<S4>,
+    T5: Conv<S5>,
+{
+    #[inline]
+    fn try_conv(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self, Error> {
+        Ok((
+            ss.0.try_cast()?,
+            ss.1.try_cast()?,
+            ss.2.try_cast()?,
+            ss.3.try_cast()?,
+            ss.4.try_cast()?,
+            ss.5.try_cast()?,
+        ))
+    }
+}

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -37,7 +37,8 @@ impl_via_from!(u16: f32, f64, i32, i64, i128, u32, u64, u128);
 impl_via_from!(u32: f64, i64, i128, u64, u128);
 impl_via_from!(u64: i128, u128);
 
-// TODO: remove T: Copy + Default bound
+// TODO(unsize): remove T: Copy + Default bound
+// TODO(specialization): implement ConvApprox for arrays and tuples
 impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
     #[inline]
     fn try_conv(ss: [S; N]) -> Result<Self, Error> {
@@ -52,6 +53,74 @@ impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::conv(s);
+        }
+        tt
+    }
+}
+
+impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for [T; N] {
+    #[inline]
+    fn try_conv_trunc(ss: [S; N]) -> Result<Self, Error> {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::try_conv_trunc(s)?;
+        }
+        Ok(tt)
+    }
+    #[inline]
+    fn try_conv_nearest(ss: [S; N]) -> Result<Self, Error> {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::try_conv_nearest(s)?;
+        }
+        Ok(tt)
+    }
+    #[inline]
+    fn try_conv_floor(ss: [S; N]) -> Result<Self, Error> {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::try_conv_floor(s)?;
+        }
+        Ok(tt)
+    }
+    #[inline]
+    fn try_conv_ceil(ss: [S; N]) -> Result<Self, Error> {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::try_conv_ceil(s)?;
+        }
+        Ok(tt)
+    }
+
+    #[inline]
+    fn conv_trunc(ss: [S; N]) -> Self {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::conv_trunc(s);
+        }
+        tt
+    }
+    #[inline]
+    fn conv_nearest(ss: [S; N]) -> Self {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::conv_nearest(s);
+        }
+        tt
+    }
+    #[inline]
+    fn conv_floor(ss: [S; N]) -> Self {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::conv_floor(s);
+        }
+        tt
+    }
+    #[inline]
+    fn conv_ceil(ss: [S; N]) -> Self {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::conv_ceil(s);
         }
         tt
     }
@@ -169,5 +238,41 @@ where
             ss.4.cast(),
             ss.5.cast(),
         )
+    }
+}
+
+impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, T1) {
+    #[inline]
+    fn try_conv_trunc(ss: (S0, S1)) -> Result<Self, Error> {
+        Ok((T0::try_conv_trunc(ss.0)?, T1::try_conv_trunc(ss.1)?))
+    }
+    #[inline]
+    fn try_conv_nearest(ss: (S0, S1)) -> Result<Self, Error> {
+        Ok((T0::try_conv_nearest(ss.0)?, T1::try_conv_nearest(ss.1)?))
+    }
+    #[inline]
+    fn try_conv_floor(ss: (S0, S1)) -> Result<Self, Error> {
+        Ok((T0::try_conv_floor(ss.0)?, T1::try_conv_floor(ss.1)?))
+    }
+    #[inline]
+    fn try_conv_ceil(ss: (S0, S1)) -> Result<Self, Error> {
+        Ok((T0::try_conv_ceil(ss.0)?, T1::try_conv_ceil(ss.1)?))
+    }
+
+    #[inline]
+    fn conv_trunc(ss: (S0, S1)) -> Self {
+        (T0::conv_trunc(ss.0), T1::conv_trunc(ss.1))
+    }
+    #[inline]
+    fn conv_nearest(ss: (S0, S1)) -> Self {
+        (T0::conv_nearest(ss.0), T1::conv_nearest(ss.1))
+    }
+    #[inline]
+    fn conv_floor(ss: (S0, S1)) -> Self {
+        (T0::conv_floor(ss.0), T1::conv_floor(ss.1))
+    }
+    #[inline]
+    fn conv_ceil(ss: (S0, S1)) -> Self {
+        (T0::conv_ceil(ss.0), T1::conv_ceil(ss.1))
     }
 }

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -58,6 +58,7 @@ impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
     }
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for [T; N] {
     #[inline]
     fn try_conv_trunc(ss: [S; N]) -> Result<Self, Error> {
@@ -241,6 +242,7 @@ where
     }
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, T1) {
     #[inline]
     fn try_conv_trunc(ss: (S0, S1)) -> Result<Self, Error> {

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -36,3 +36,15 @@ impl_via_from!(u8: u16, u32, u64, u128);
 impl_via_from!(u16: f32, f64, i32, i64, i128, u32, u64, u128);
 impl_via_from!(u32: f64, i64, i128, u64, u128);
 impl_via_from!(u64: i128, u128);
+
+// TODO: remove T: Copy + Default bound
+impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
+    #[inline]
+    fn try_conv(ss: [S; N]) -> Result<Self, Error> {
+        let mut tt = [T::default(); N];
+        for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
+            *t = T::try_conv(s)?;
+        }
+        Ok(tt)
+    }
+}

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -7,17 +7,6 @@
 
 use super::*;
 
-impl<T> Conv<T> for T {
-    #[inline]
-    fn conv(v: T) -> Self {
-        v
-    }
-    #[inline]
-    fn try_conv(v: T) -> Result<Self, Error> {
-        Ok(v)
-    }
-}
-
 macro_rules! impl_via_from {
     ($x:ty: $y:ty) => {
         impl Conv<$x> for $y {

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -182,6 +182,17 @@ macro_rules! impl_float {
                 }
             }
         }
+
+        impl ConvApprox<$x> for $y {
+            #[inline]
+            fn try_conv_approx(x: $x) -> Result<Self, Error> {
+                ConvFloat::<$x>::try_conv_trunc(x)
+            }
+            #[inline]
+            fn conv_approx(x: $x) -> Self {
+                ConvFloat::<$x>::conv_trunc(x)
+            }
+        }
     };
     ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_float!($x: $y);
@@ -268,5 +279,16 @@ impl ConvFloat<f32> for u128 {
         } else {
             Err(Error::Range)
         }
+    }
+}
+
+impl ConvApprox<f32> for u128 {
+    #[inline]
+    fn try_conv_approx(x: f32) -> Result<Self, Error> {
+        ConvFloat::<f32>::try_conv_trunc(x)
+    }
+    #[inline]
+    fn conv_approx(x: f32) -> Self {
+        ConvFloat::<f32>::conv_trunc(x)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,18 @@ impl<S, T: Conv<S>> Cast<T> for S {
     }
 }
 
+/// Like [`From`], but for approximate numerical conversions
+pub trait ConvApprox<T>: Sized {
+    /// Try converting from `T` to `Self`, allowing approximation of value
+    fn try_conv_approx(x: T) -> Result<Self, Error>;
+
+    /// Converting from `T` to `Self`, allowing approximation of value
+    fn conv_approx(x: T) -> Self {
+        Self::try_conv_approx(x)
+            .unwrap_or_else(|e| panic!("ConvApprox::conv_approx(_) failed: {}", e))
+    }
+}
+
 /// Nearest / floor / ceiling conversions from floating point types
 ///
 /// This trait is explicitly for conversions from floating-point values to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,8 @@ impl<S, T: Conv<S>> Cast<T> for S {
 
 /// Like [`From`], but for approximate numerical conversions
 ///
-/// This trait is implemented for all conversions supported by [`ConvFloat`].
+/// This trait is implemented for all conversions supported by [`Conv`] and
+/// [`ConvFloat`] (but the latter impls only as provided by this library).
 /// Prefer to use [`ConvFloat`] or [`CastFloat`] where precise control over
 /// rounding is required.
 ///
@@ -201,15 +202,15 @@ pub trait ConvApprox<T>: Sized {
     }
 }
 
-// TODO(specialization): implement also where T: Conv<S>
-impl<S, T: ConvFloat<S>> ConvApprox<S> for T {
+// TODO(specialization): implement also where T: ConvFloat<S>
+impl<S, T: Conv<S>> ConvApprox<S> for T {
     #[inline]
     fn try_conv_approx(x: S) -> Result<Self, Error> {
-        T::try_conv_trunc(x)
+        T::try_conv(x)
     }
     #[inline]
     fn conv_approx(x: S) -> Self {
-        T::conv_trunc(x)
+        T::conv(x)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,8 @@ pub enum Error {
     Inexact,
 }
 
-#[cfg(feature = "std")]
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Range => write!(f, "source value not in target range"),
             Error::Inexact => write!(f, "loss of precision or range error"),
@@ -123,7 +122,9 @@ pub trait Conv<T>: Sized {
     /// arithmetic in that it is a tool for diagnosing logic errors where
     /// success is expected.
     fn conv(v: T) -> Self {
-        Self::try_conv(v).unwrap_or_else(|e| panic!("Conv::conv(_) failed: {}", e))
+        Self::try_conv(v).unwrap_or_else(|e| {
+            panic!("Conv::conv(_) failed: {}", e);
+        })
     }
 }
 
@@ -197,8 +198,9 @@ pub trait ConvApprox<T>: Sized {
     /// success is expected.
     #[inline]
     fn conv_approx(x: T) -> Self {
-        Self::try_conv_approx(x)
-            .unwrap_or_else(|e| panic!("ConvApprox::conv_approx(_) failed: {}", e))
+        Self::try_conv_approx(x).unwrap_or_else(|e| {
+            panic!("ConvApprox::conv_approx(_) failed: {}", e);
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,44 +5,43 @@
 
 //! Type conversion, success expected
 //!
-//! This library is written to make numeric type conversions easy. Such
-//! conversions usually fall into one of the following cases:
+//! This library exists to make fallible numeric type conversions easy, without
+//! resorting to the `as` keyword.
 //!
-//! -   the conversion must preserve values exactly (use [`From`] or [`Into`]
-//!     or [`Conv`] or [`Cast`])
-//! -   the conversion is expected to preserve values exactly, though this is
-//!     not ensured by the types in question (use [`Conv`] or [`Cast`])
-//! -   the conversion could fail and must be checked at run-time (use
-//!     [`TryFrom`] or [`TryInto`] or [`Conv::try_conv`] or [`Cast::try_cast`])
-//! -   the conversion is from floating point values to integers and should
-//!     round to the "nearest" integer (use [`ConvFloat`] or [`CastFloat`])
-//! -   the conversion is from `f32` to `f64` or vice-versa; in this case use of
-//!     `as f32` / `as f64` is likely acceptable since `f32` has special
-//!     representations for non-finite values and conversion to `f64` is exact
-//! -   truncating conversion (modular arithmetic) is desired; in this case `as`
-//!     probably does exactly what you want
-//! -   saturating conversion is desired (less common; not supported here)
+//! -   [`Conv`] is like [`From`], but supports fallible conversions
+//! -   [`Cast`] is to [`Conv`] what [`Into`] is to [`From`]
+//! -   [`ConvApprox`] and [`CastApprox`] support fallible, approximate conversion
+//! -   [`ConvFloat`] and [`CastFloat`] are similar, providing precise control over rounding
 //!
 //! If you are wondering "why not just use `as`", there are a few reasons:
 //!
-//! -   integer conversions may silently truncate
-//! -   integer conversions to/from signed types silently reinterpret
+//! -   integer conversions may silently truncate or sign-extend which does not
+//!     preserve value
 //! -   prior to Rust 1.45.0 float-to-int conversions were not fully defined;
 //!     since this version they use saturating conversion (NaN converts to 0)
 //! -   you want some assurance (at least in debug builds) that the conversion
-//!     will preserve values correctly without having to proof-read code
+//!     will preserve values correctly
 //!
-//! When should you *not* use this library?
+//! Why might you *not* want to use this library?
 //!
-//! -   Only numeric conversions are supported
-//! -   Conversions from floats do not provide fine control of rounding modes
-//! -   This library has not been thoroughly tested correctness
+//! -   You want saturating / truncating / other non-value-preserving conversion
+//! -   You want to convert non-numeric types ([`From`] supports a lot more
+//!     conversions than [`Conv`] does)!
+//! -   You want a thoroughly tested library (we're not quite there yet)
 //!
-//! ## Assertions
+//! ## Error handling
 //!
-//! All type conversions which are potentially fallible assert on failure in
-//! debug builds. In release builds assertions may be omitted, thus making
-//! incorrect conversions possible.
+//! All traits support two methods:
+//!
+//! -   `try_*` methods return a `Result` and always fail if the correct
+//!     conversion is not possible
+//! -   other methods may panic or return incorrect results
+//!
+//! In debug builds, methods not returning `Result` must panic on failure. As
+//! with the overflow checks on Rust's standard integer arithmetic, this is
+//! considered a tool for finding logic errors. In release builds, these methods
+//! are permitted to return defined but incorrect results similar to the `as`
+//! keyword.
 //!
 //! If the `always_assert` feature flag is set, assertions will be turned on in
 //! all builds. Some additional feature flags are available for finer-grained

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,17 +49,28 @@ fn int_to_float_inexact() {
 }
 
 #[test]
-fn approx() {
+fn approx_float_to_int() {
+    assert_eq!(i32::conv_approx(1.99f32), 1);
+    assert_eq!(i32::conv_approx(-1.99f32), -1);
+    assert_eq!(i32::conv_approx(9.1f64), 9);
+
+    const MAX: f64 = i32::MAX as f64;
+    assert_eq!(i32::conv_approx(MAX), i32::MAX);
+    assert_eq!(i32::conv_approx(MAX + 0.9), i32::MAX);
+    assert_eq!(i32::try_conv_approx(MAX + 1.0), Err(Error::Range));
+}
+
+#[test]
+fn approx_f64_f32() {
     assert_eq!(f32::conv_approx(0f64), 0f32);
     assert_eq!(f32::conv_approx(0f64).is_sign_positive(), true);
     assert_eq!(f32::conv_approx(-0f64).is_sign_negative(), true);
 
+    const E32: f64 = f32::EPSILON as f64;
     assert_eq!(f32::conv_approx(1f64), 1f32);
-    assert_eq!(
-        f32::conv_approx(1f64 + f32::EPSILON as f64),
-        1f32 + f32::EPSILON
-    );
-    assert_eq!(f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0), 1f32);
+    assert_eq!(f32::conv_approx(1f64 + E32), 1f32 + f32::EPSILON);
+    assert_eq!(f32::conv_approx(1f64 + E32 / 2.0), 1f32);
+    assert_eq!(f32::conv_approx(1f64 + E32 - f64::EPSILON), 1f32);
 
     assert_eq!(f32::conv_approx(-10f64), -10f32);
     assert!((f32::conv_approx(1f64 / 3.0) - 1f32 / 3.0).abs() <= f32::EPSILON);
@@ -68,10 +79,7 @@ fn approx() {
     assert_eq!(f32::conv_approx(MAX), f32::MAX);
     assert!(MAX + 2f64.powi(103) != MAX);
     assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::MAX);
-    assert_eq!(
-        f32::try_conv_approx(f32::MAX as f64 * 2.0),
-        Err(Error::Range)
-    );
+    assert_eq!(f32::try_conv_approx(MAX * 2.0), Err(Error::Range));
 
     assert_eq!(
         f32::conv_approx(f64::INFINITY).to_bits(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,7 @@ fn int_to_float_inexact() {
 }
 
 #[test]
+#[cfg(any(feature = "std", feature = "libm"))]
 fn approx_float_to_int() {
     assert_eq!(i32::conv_approx(1.99f32), 1);
     assert_eq!(i32::conv_approx(-1.99f32), -1);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,7 +17,7 @@ fn signed_to_unsigned() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "cast x: i32 to u32: expected x >= 0, found x = -1")]
 fn signed_to_unsigned_n1() {
     u32::conv(-1i32);
 }
@@ -30,7 +30,7 @@ fn unsigned_to_signed() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "cast x: u32 to i32: expected x <= 2147483647, found x = 2147483648")]
 fn unsigned_to_signed_large() {
     i32::conv(0x8000_0000u32);
 }
@@ -43,7 +43,7 @@ fn int_to_float() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "cast x: i32 to f32: inexact for x = 33554431")]
 fn int_to_float_inexact() {
     f32::conv(0x01FF_FFFF);
 }
@@ -108,14 +108,14 @@ fn float_trunc() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "cast x: f32 to i16 (trunc): range error for x = 32768")]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_trunc_fail1() {
     i16::conv_trunc(32768.0f32);
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "cast x: u32 to f32: inexact for x = 4294967295")]
 fn u32_max_f32() {
     f32::conv(core::u32::MAX);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -49,6 +49,44 @@ fn int_to_float_inexact() {
 }
 
 #[test]
+fn approx() {
+    assert_eq!(f32::conv_approx(0f64), 0f32);
+    assert_eq!(f32::conv_approx(0f64).is_sign_positive(), true);
+    assert_eq!(f32::conv_approx(-0f64).is_sign_negative(), true);
+
+    assert_eq!(f32::conv_approx(1f64), 1f32);
+    assert_eq!(
+        f32::conv_approx(1f64 + f32::EPSILON as f64),
+        1f32 + f32::EPSILON
+    );
+    assert_eq!(f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0), 1f32);
+
+    assert_eq!(f32::conv_approx(-10f64), -10f32);
+    assert!((f32::conv_approx(1f64 / 3.0) - 1f32 / 3.0).abs() <= f32::EPSILON);
+
+    const MAX: f64 = f32::MAX as f64;
+    assert_eq!(f32::conv_approx(MAX), f32::MAX);
+    assert!(MAX + 2f64.powi(103) != MAX);
+    assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::MAX);
+    assert_eq!(
+        f32::try_conv_approx(f32::MAX as f64 * 2.0),
+        Err(Error::Range)
+    );
+
+    assert_eq!(
+        f32::conv_approx(f64::INFINITY).to_bits(),
+        f32::INFINITY.to_bits()
+    );
+    assert_eq!(f32::try_conv_approx(f64::NAN), Err(Error::Range));
+}
+
+#[test]
+#[should_panic(expected = "cast x: f64 to f32 (approx): range error for x = NaN")]
+fn approx_nan() {
+    f32::conv_approx(f64::NAN);
+}
+
+#[test]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_casts() {
     assert_eq!(u64::conv_nearest(13.2f32), 13);


### PR DESCRIPTION
This will likely be released as 0.5:

- `conv` methods now have default implementations over `try_conv` methods to ease third-party implementations
- Add `ConvApprox` and `CastApprox` for *approximate* conversions without specific rounding; implement for `f64 -> f32`
- `ConvApprox<T>` is auto-implemented over `Conv<T>`
- Support arrays and tuples for `Conv` and `ConvFloat` (and therefore `Cast` and `CastFloat`); closes #19 
- Update documentation
- MSRV is now 1.53.0

Limitations due to lack of specialization (or other conflicting-trait-impl resolution):

- `impl<T> Conv<T> for T` was removed
- we cannot implement array/tuple support for `ConvApprox`
- we cannot auto-implement `ConvApprox<T>` over `ConvFloat<T>`

Limitation due to unsized-type support:

- array implementations require `T: Copy + Default` and may not be optimal

Limitations due to code size:

- `Conv` supports 0-6 element tuples
- `ConvFloat` only supports 2-tuples
