### PR TITLE
Bump MSRV; implement `Conv` for `core::{num, ops}` types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.60.0"
+          toolchain: "1.74.0"
       - name: Use Cargo.lock.msrv
         run: cp Cargo.lock.msrv Cargo.lock
       - name: Test

--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -11,6 +11,6 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
+checksum = "a00419de735aac21d53b0de5ce2c03bd3627277cf471300f27ebc89f7d828047"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 documentation = "https://docs.rs/easy-cast/"
 keywords = ["cast", "into", "from", "conversion"]
 repository = "https://github.com/kas-gui/easy-cast"
-rust-version = "1.60.0"
+rust-version = "1.74.0"
 
 [package.metadata.docs.rs]
 features = []

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! `core::num` impls for Conv.
+
+use super::*;
+use core::num::{Saturating, Wrapping};
+
+impl<F, T: Conv<F>> Conv<Saturating<F>> for Saturating<T> {
+    #[inline]
+    fn try_conv(n: Saturating<F>) -> Result<Saturating<T>> {
+        n.0.try_cast().map(Saturating)
+    }
+
+    #[inline]
+    fn conv(n: Saturating<F>) -> Saturating<T> {
+        Saturating(n.0.cast())
+    }
+}
+
+impl<F, T: Conv<F>> Conv<Wrapping<F>> for Wrapping<T> {
+    #[inline]
+    fn try_conv(n: Wrapping<F>) -> Result<Wrapping<T>> {
+        n.0.try_cast().map(Wrapping)
+    }
+
+    #[inline]
+    fn conv(n: Wrapping<F>) -> Wrapping<T> {
+        Wrapping(n.0.cast())
+    }
+}

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! `core::ops` impls for Conv.
+
+use super::*;
+use core::ops::Range;
+
+impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
+    #[inline]
+    fn try_conv(n: Range<F>) -> Result<Range<T>> {
+        Ok(Range {
+            start: n.start.try_cast()?,
+            end: n.end.try_cast()?,
+        })
+    }
+
+    #[inline]
+    fn conv(n: Range<F>) -> Range<T> {
+        Range {
+            start: n.start.cast(),
+            end: n.end.cast(),
+        }
+    }
+}

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -6,7 +6,7 @@
 //! `core::ops` impls for Conv.
 
 use super::*;
-use core::ops::Range;
+use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
 impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
     #[inline]
@@ -23,5 +23,65 @@ impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
             start: n.start.cast(),
             end: n.end.cast(),
         }
+    }
+}
+
+impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
+    #[inline]
+    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>> {
+        let start = n.start().clone().try_cast()?;
+        let end = n.end().clone().try_cast()?;
+        Ok(RangeInclusive::new(start, end))
+    }
+
+    #[inline]
+    fn conv(n: RangeInclusive<F>) -> RangeInclusive<T> {
+        let start = n.start().clone().cast();
+        let end = n.end().clone().cast();
+        RangeInclusive::new(start, end)
+    }
+}
+
+impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
+    #[inline]
+    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>> {
+        Ok(RangeFrom {
+            start: n.start.try_cast()?,
+        })
+    }
+
+    #[inline]
+    fn conv(n: RangeFrom<F>) -> RangeFrom<T> {
+        RangeFrom {
+            start: n.start.cast(),
+        }
+    }
+}
+
+impl<F, T: Conv<F>> Conv<RangeTo<F>> for RangeTo<T> {
+    #[inline]
+    fn try_conv(n: RangeTo<F>) -> Result<RangeTo<T>> {
+        Ok(RangeTo {
+            end: n.end.try_cast()?,
+        })
+    }
+
+    #[inline]
+    fn conv(n: RangeTo<F>) -> RangeTo<T> {
+        RangeTo { end: n.end.cast() }
+    }
+}
+
+impl<F, T: Conv<F>> Conv<RangeToInclusive<F>> for RangeToInclusive<T> {
+    #[inline]
+    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>> {
+        Ok(RangeToInclusive {
+            end: n.end.try_cast()?,
+        })
+    }
+
+    #[inline]
+    fn conv(n: RangeToInclusive<F>) -> RangeToInclusive<T> {
+        RangeToInclusive { end: n.end.cast() }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ mod impl_basic;
 mod impl_float;
 mod impl_int;
 mod impl_num;
+mod impl_ops;
 
 pub mod traits;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 mod impl_basic;
 mod impl_float;
 mod impl_int;
+mod impl_num;
 
 pub mod traits;
 

--- a/tests/core-types.rs
+++ b/tests/core-types.rs
@@ -1,4 +1,5 @@
 use core::num::{Saturating, Wrapping};
+use core::ops::Range;
 use easy_cast::traits::*;
 
 #[test]
@@ -17,4 +18,11 @@ fn wrapping_casts() {
     let c = Wrapping::<u8>::conv(b);
     let d = c.cast();
     assert_eq!(a, d);
+}
+
+#[test]
+fn range_cast() {
+    let a: Range<usize> = 10..20;
+    let b: Range<u8> = a.cast();
+    assert_eq!(b, 10..20);
 }

--- a/tests/core-types.rs
+++ b/tests/core-types.rs
@@ -1,0 +1,20 @@
+use core::num::{Saturating, Wrapping};
+use easy_cast::traits::*;
+
+#[test]
+fn saturating_casts() {
+    let a: Saturating<i32> = Saturating(213);
+    let b: Saturating<u128> = a.cast();
+    let c = Saturating::<u8>::conv(b);
+    let d = c.cast();
+    assert_eq!(a, d);
+}
+
+#[test]
+fn wrapping_casts() {
+    let a: Wrapping<i32> = Wrapping(213);
+    let b: Wrapping<u128> = a.cast();
+    let c = Wrapping::<u8>::conv(b);
+    let d = c.cast();
+    assert_eq!(a, d);
+}

--- a/tests/core-types.rs
+++ b/tests/core-types.rs
@@ -1,5 +1,5 @@
 use core::num::{Saturating, Wrapping};
-use core::ops::Range;
+use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 use easy_cast::traits::*;
 
 #[test]
@@ -25,4 +25,35 @@ fn range_cast() {
     let a: Range<usize> = 10..20;
     let b: Range<u8> = a.cast();
     assert_eq!(b, 10..20);
+}
+
+#[test]
+fn range_inclusive_cast() {
+    let a: RangeInclusive<usize> = 0..=255;
+    let b: RangeInclusive<u8> = a.cast();
+    assert_eq!(b, 0..=255);
+
+    let c: RangeInclusive<usize> = 0..=256;
+    assert!(RangeInclusive::<u8>::try_conv(c).is_err());
+}
+
+#[test]
+fn range_from_cast() {
+    let a: RangeFrom<i32> = -12..;
+    let b: RangeFrom<i8> = a.cast();
+    assert_eq!(b, -12..);
+}
+
+#[test]
+fn range_to_cast() {
+    let a: RangeTo<i32> = ..-12;
+    let b: RangeTo<i8> = a.cast();
+    assert_eq!(b, ..-12);
+}
+
+#[test]
+fn range_to_inclusive_cast() {
+    let a: RangeToInclusive<i8> = ..=127;
+    let b: RangeToInclusive<i16> = a.cast();
+    assert_eq!(b, ..=127);
 }


### PR DESCRIPTION
This supports `Cast` on `Saturating`, `Wrapping` and all `std::ops::Range*` types (excluding `RangeFull` which has no value).

There is already (limited) support for arrays and tuples.

Besides `NonZero*` (see #36), this covers all `std` types which I think should be covered, though there are a few others which *could* be supported:

- `Option<T>`, `Result<T, _>`: possible, but probably better style to use `.map`
- `Box<T>`, `Cow<T>`: possible, but seems pretty useless