### PR TITLE
Support conversions on `NonZero<T>`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.74.0"
+          toolchain: "1.79.0"
       - name: Use Cargo.lock.msrv
         run: cp Cargo.lock.msrv Cargo.lock
       - name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libm = ["dep:libm"]
 # Note: assertions are always used in debug builds; these only affect release builds:
 
 # Always use all assertions
-always_assert = ["assert_float", "assert_int", "assert_digits"]
+always_assert = ["assert_float", "assert_int", "assert_digits", "assert_nonzero"]
 
 # Assert float -> any conversions do not exceed range of target type
 assert_float = []
@@ -38,6 +38,9 @@ assert_int = []
 
 # Assert int -> float conversion does not lose accuracy
 assert_digits = []
+
+# Always assert NonZero constructions are non-zero
+assert_nonzero = []
 
 [dependencies.libm]
 version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 documentation = "https://docs.rs/easy-cast/"
 keywords = ["cast", "into", "from", "conversion"]
 repository = "https://github.com/kas-gui/easy-cast"
-rust-version = "1.74.0"
+rust-version = "1.79.0"
 
 [package.metadata.docs.rs]
 features = []

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -6,7 +6,7 @@
 //! `core::num` impls for Conv.
 
 use super::*;
-use core::num::{Saturating, Wrapping};
+use core::num::{NonZero, Saturating, Wrapping, ZeroablePrimitive};
 
 impl<F, T: Conv<F>> Conv<Saturating<F>> for Saturating<T> {
     #[inline]
@@ -29,5 +29,29 @@ impl<F, T: Conv<F>> Conv<Wrapping<F>> for Wrapping<T> {
     #[inline]
     fn conv(n: Wrapping<F>) -> Wrapping<T> {
         Wrapping(n.0.cast())
+    }
+}
+
+impl<F: ZeroablePrimitive, T: Conv<F> + ZeroablePrimitive> Conv<NonZero<F>> for NonZero<T> {
+    #[inline]
+    fn try_conv(n: NonZero<F>) -> Result<NonZero<T>> {
+        let m: T = n.get().try_cast()?;
+        Ok(if cfg!(debug_assertions) {
+            NonZero::new(m).expect("should be non-zero")
+        } else {
+            // SAFETY: since cast() does not change the numeric value, m cannot be zero
+            unsafe { NonZero::new_unchecked(m) }
+        })
+    }
+
+    #[inline]
+    fn conv(n: NonZero<F>) -> NonZero<T> {
+        let m: T = n.get().cast();
+        if cfg!(debug_assertions) {
+            NonZero::new(m).expect("should be non-zero")
+        } else {
+            // SAFETY: since cast() does not change the numeric value, m cannot be zero
+            unsafe { NonZero::new_unchecked(m) }
+        }
     }
 }

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -6,7 +6,7 @@
 //! `core::num` impls for Conv.
 
 use super::*;
-use core::num::{NonZero, Saturating, Wrapping, ZeroablePrimitive};
+use core::num::{NonZero, Saturating, Wrapping};
 
 impl<F, T: Conv<F>> Conv<Saturating<F>> for Saturating<T> {
     #[inline]
@@ -32,26 +32,104 @@ impl<F, T: Conv<F>> Conv<Wrapping<F>> for Wrapping<T> {
     }
 }
 
-impl<F: ZeroablePrimitive, T: Conv<F> + ZeroablePrimitive> Conv<NonZero<F>> for NonZero<T> {
-    #[inline]
-    fn try_conv(n: NonZero<F>) -> Result<NonZero<T>> {
-        let m: T = n.get().try_cast()?;
-        Ok(if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
-            NonZero::new(m).expect("should be non-zero")
-        } else {
-            // SAFETY: since cast() does not change the numeric value, m cannot be zero
-            unsafe { NonZero::new_unchecked(m) }
-        })
-    }
-
-    #[inline]
-    fn conv(n: NonZero<F>) -> NonZero<T> {
-        let m: T = n.get().cast();
-        if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
-            NonZero::new(m).expect("should be non-zero")
-        } else {
-            // SAFETY: since cast() does not change the numeric value, m cannot be zero
-            unsafe { NonZero::new_unchecked(m) }
+macro_rules! impl_via_trivial {
+    ($x:ty) => {
+        impl Conv<NonZero<$x>> for NonZero<$x> {
+            #[inline]
+            fn conv(x: NonZero<$x>) -> Self {
+                x
+            }
+            #[inline]
+            fn try_conv(x: NonZero<$x>) -> Result<Self> {
+                Ok(x)
+            }
         }
-    }
+    };
+    ($x:ty $(, $xx:tt)* $(,)?) => {
+        impl_via_trivial!($x);
+        impl_via_trivial!($($xx),*);
+    };
 }
+
+#[rustfmt::skip]
+impl_via_trivial!(
+    u8, u16, u32, u64, u128, usize,
+    i8, i16, i32, i64, i128, isize,
+);
+
+macro_rules! impl_nonzero {
+    ($x:ty: $y:ty) => {
+        impl Conv<NonZero<$x>> for NonZero<$y> {
+            #[inline]
+            fn try_conv(n: NonZero<$x>) -> Result<NonZero<$y>> {
+                let m: $y = n.get().try_cast()?;
+                Ok(if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
+                    NonZero::new(m).expect("should be non-zero")
+                } else {
+                    // SAFETY: since cast() does not change the numeric value, m cannot be zero
+                    unsafe { NonZero::new_unchecked(m) }
+                })
+            }
+
+            #[inline]
+            fn conv(n: NonZero<$x>) -> NonZero<$y> {
+                let m: $y = n.get().cast();
+                if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
+                    NonZero::new(m).expect("should be non-zero")
+                } else {
+                    // SAFETY: since cast() does not change the numeric value, m cannot be zero
+                    unsafe { NonZero::new_unchecked(m) }
+                }
+            }
+        }
+    };
+    ($x:ty: $y:ty, $($yy:ty),+) => {
+        impl_nonzero!($x: $y);
+        impl_nonzero!($x: $($yy),+);
+    };
+}
+
+// From impl_basic:
+impl_nonzero!(i8: i16, i32, i64, i128);
+impl_nonzero!(i16: i32, i64, i128);
+impl_nonzero!(i32: i64, i128);
+impl_nonzero!(i64: i128);
+impl_nonzero!(u8: i16, i32, i64, i128);
+impl_nonzero!(u8: u16, u32, u64, u128);
+impl_nonzero!(u16: i32, i64, i128, u32, u64, u128);
+impl_nonzero!(u32: i64, i128, u64, u128);
+impl_nonzero!(u64: i128, u128);
+
+// From impl_int:
+impl_nonzero!(i8: u8, u16, u32, u64, u128);
+impl_nonzero!(i16: u16, u32, u64, u128);
+impl_nonzero!(i32: u32, u64, u128);
+impl_nonzero!(i64: u64, u128);
+impl_nonzero!(i128: u128);
+
+impl_nonzero!(u8: i8);
+impl_nonzero!(u16: i8, i16, u8);
+impl_nonzero!(u32: i8, i16, i32, u8, u16);
+impl_nonzero!(u64: i8, i16, i32, i64, u8, u16, u32);
+impl_nonzero!(u128: i8, i16, i32, i64, i128);
+impl_nonzero!(u128: u8, u16, u32, u64);
+
+impl_nonzero!(i16: i8, u8);
+impl_nonzero!(i32: i8, i16, u8, u16);
+impl_nonzero!(i64: i8, i16, i32, u8, u16, u32);
+impl_nonzero!(i128: i8, i16, i32, i64, u8, u16, u32, u64);
+
+impl_nonzero!(i8: isize, usize);
+impl_nonzero!(i16: isize, usize);
+impl_nonzero!(i32: isize, usize);
+impl_nonzero!(i64: isize, usize);
+impl_nonzero!(i128: isize, usize);
+impl_nonzero!(u8: isize, usize);
+impl_nonzero!(u16: isize, usize);
+impl_nonzero!(u32: isize, usize);
+impl_nonzero!(u64: isize, usize);
+impl_nonzero!(u128: isize, usize);
+impl_nonzero!(isize: i8, i16, i32, i64, i128);
+impl_nonzero!(usize: i8, i16, i32, i64, i128, isize);
+impl_nonzero!(isize: u8, u16, u32, u64, u128, usize);
+impl_nonzero!(usize: u8, u16, u32, u64, u128);

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -36,7 +36,7 @@ impl<F: ZeroablePrimitive, T: Conv<F> + ZeroablePrimitive> Conv<NonZero<F>> for 
     #[inline]
     fn try_conv(n: NonZero<F>) -> Result<NonZero<T>> {
         let m: T = n.get().try_cast()?;
-        Ok(if cfg!(debug_assertions) {
+        Ok(if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
             NonZero::new(m).expect("should be non-zero")
         } else {
             // SAFETY: since cast() does not change the numeric value, m cannot be zero
@@ -47,7 +47,7 @@ impl<F: ZeroablePrimitive, T: Conv<F> + ZeroablePrimitive> Conv<NonZero<F>> for 
     #[inline]
     fn conv(n: NonZero<F>) -> NonZero<T> {
         let m: T = n.get().cast();
-        if cfg!(debug_assertions) {
+        if cfg!(any(debug_assertions, feature = "assert_nonzero")) {
             NonZero::new(m).expect("should be non-zero")
         } else {
             // SAFETY: since cast() does not change the numeric value, m cannot be zero

--- a/tests/core-types.rs
+++ b/tests/core-types.rs
@@ -1,6 +1,15 @@
-use core::num::{Saturating, Wrapping};
+use core::num::*;
 use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 use easy_cast::traits::*;
+
+#[test]
+fn nonzero_casts() {
+    let a = NonZeroI32::new(213).unwrap();
+    let b: NonZero<u128> = a.cast();
+    let c = NonZeroU8::conv(b);
+    let d = c.cast();
+    assert_eq!(a, d);
+}
 
 #[test]
 fn saturating_casts() {


### PR DESCRIPTION
Fixes #33 using `macro_rules!`. Ugly but workable.