### PR TITLE
Simplify ConvApprox<f64> for f32: use as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+-   Adjust `ConvApprox<f64> for f32` to behave more like `*_f64 as f32`:
+    too-large values round to infinity (instead of a range error) and rounding
+    uses `roundTiesToEven`. Unlike `as f32`, NAN still yields
+    `Err(Error::Range)`. (#47)
+
 ## [0.5.5] — 2026-07-08
 
 -   Bump MSRV to 1.96.0 and use Edition 2024 (#44)

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -10,31 +10,9 @@ use super::*;
 #[allow(clippy::manual_range_contains)]
 impl ConvApprox<f64> for f32 {
     fn try_conv_approx(x: f64) -> Result<f32> {
-        use core::num::FpCategory;
-
-        let sign_bits = (x.to_bits() >> 32) as u32 & 0x8000_0000;
-        let with_sign = |x: f32| -> f32 {
-            // assumption: x is not negative
-            f32::from_bits(sign_bits | x.to_bits())
-        };
-
-        match x.classify() {
-            FpCategory::Nan => Err(Error::Range),
-            FpCategory::Infinite => Ok(with_sign(f32::INFINITY)),
-            FpCategory::Zero | FpCategory::Subnormal => Ok(with_sign(0f32)),
-            FpCategory::Normal => {
-                // f32 exponent range: -126 to 127
-                // f64, f32 bias: 1023, 127 represents 0
-                let exp = (x.to_bits() & 0x7FF0_0000_0000_0000) >> 52;
-                if exp >= 1023 - 126 && exp <= 1023 + 127 {
-                    let exp = ((exp + 127) - 1023) as u32;
-                    let frac = ((x.to_bits() & 0x000F_FFFF_FFFF_FFFF) >> (52 - 23)) as u32;
-                    let bits = sign_bits | (exp << 23) | frac;
-                    Ok(f32::from_bits(bits))
-                } else {
-                    Err(Error::Range)
-                }
-            }
+        match x.is_nan() {
+            false => Ok(x as f32),
+            true => Err(Error::Range),
         }
     }
 

--- a/tests/conv_approx.rs
+++ b/tests/conv_approx.rs
@@ -39,6 +39,6 @@ fn conv_approx_for_f64_to_f32_uses_truncation() {
         f32::conv_approx(f64::INFINITY).to_bits(),
         f32::INFINITY.to_bits()
     );
-    assert_eq!(f32::try_conv_approx(f64::MAX), Err(Error::Range));
+    assert_eq!(f32::try_conv_approx(f64::MAX), Ok(f32::INFINITY));
     assert_eq!(f32::try_conv_approx(f64::NAN), Err(Error::Range));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -91,16 +91,20 @@ fn approx_f64_f32() {
     assert_eq!(f32::conv_approx(1f64), 1f32);
     assert_eq!(f32::conv_approx(1f64 + E32), 1f32 + f32::EPSILON);
     assert_eq!(f32::conv_approx(1f64 + E32 / 2.0), 1f32);
-    assert_eq!(f32::conv_approx(1f64 + E32 - f64::EPSILON), 1f32);
+    assert_eq!(
+        f32::conv_approx((1f64 + E32 / 2.0).next_up()),
+        1f32.next_up()
+    );
 
     assert_eq!(f32::conv_approx(-10f64), -10f32);
     assert!((f32::conv_approx(1f64 / 3.0) - 1f32 / 3.0).abs() <= f32::EPSILON);
 
     const MAX: f64 = f32::MAX as f64;
     assert_eq!(f32::conv_approx(MAX), f32::MAX);
-    assert!(MAX + 2f64.powi(103) != MAX);
-    assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::MAX);
-    assert_eq!(f32::try_conv_approx(MAX * 2.0), Err(Error::Range));
+    // last non-zero binary digits of mantissa are 1101, which rounds down:
+    assert_eq!(f32::conv_approx(MAX + 2f64.powi(102)), f32::MAX);
+    // last non-zero binary digits of mantissa are 1110, which rounds up:
+    assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::INFINITY);
 
     assert_eq!(
         f32::conv_approx(f64::INFINITY).to_bits(),


### PR DESCRIPTION
Abandons the custom code for `f64` → `f32` conversion in favour of using the `as` [operator expression](https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric.float-narrowing) (with a check for NAN). This changes the behaviour slightly:

- Too-large values now round to infinity instead of being reported as a range error (arguably this was a bug)
- Excess precision is rounded using `roundTiesToEven` instead of truncation. Note that `ConvApprox` does not specify a rounding mode, only that the result is semantically close to the input (which remains the case). Note also that this affects the largest value which rounds to `f32::MAX`.