### PR TITLE
Change Conv<f32> for f64 to trap NAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
     too-large values round to infinity (instead of a range error) and rounding
     uses `roundTiesToEven`. Unlike `as f32`, NAN still yields
     `Err(Error::Range)`. (#47)
+-   Change `Conv<f32> for f64` to trap NAN (#48)
 
 ## [0.5.5] — 2026-07-08
 

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -26,7 +26,6 @@ macro_rules! impl_via_from {
     };
 }
 
-impl_via_from!(f32: f64);
 impl_via_from!(i8: f32, f64, i16, i32, i64, i128);
 impl_via_from!(i16: f32, f64, i32, i64, i128);
 impl_via_from!(i32: f64, i64, i128);

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -7,6 +7,30 @@
 
 use super::*;
 
+impl Conv<f32> for f64 {
+    fn try_conv(x: f32) -> Result<Self> {
+        match x.is_nan() {
+            false => Ok(x as f64),
+            true => Err(Error::Range),
+        }
+    }
+
+    #[inline]
+    fn conv(x: f32) -> f64 {
+        fn trap_nan(x: f32) {
+            if x.is_nan() {
+                panic!("cast float-to-float: NaN")
+            }
+        }
+
+        if cfg!(any(debug_assertions, feature = "assert_float")) {
+            trap_nan(x)
+        }
+
+        x as f64
+    }
+}
+
 #[allow(clippy::manual_range_contains)]
 impl ConvApprox<f64> for f32 {
     fn try_conv_approx(x: f64) -> Result<f32> {
@@ -16,14 +40,19 @@ impl ConvApprox<f64> for f32 {
         }
     }
 
+    #[inline]
     fn conv_approx(x: f64) -> f32 {
-        if cfg!(any(debug_assertions, feature = "assert_float")) {
-            Self::try_conv_approx(x).unwrap_or_else(|_| {
-                panic!("cast x: f64 to f32 (approx): range error for x = {}", x)
-            })
-        } else {
-            x as f32
+        fn trap_nan(x: f64) {
+            if x.is_nan() {
+                panic!("cast float-to-float: NaN")
+            }
         }
+
+        if cfg!(any(debug_assertions, feature = "assert_float")) {
+            trap_nan(x)
+        }
+
+        x as f32
     }
 }
 

--- a/tests/float_conv.rs
+++ b/tests/float_conv.rs
@@ -59,6 +59,50 @@ fn nan_and_infinity_are_range_errors_for_all_modes() {
 }
 
 #[test]
+#[should_panic(expected = "cast float-to-float: NaN")]
+fn f32_nan_to_f64() {
+    f64::conv(f32::NAN);
+}
+
+#[test]
+#[should_panic(expected = "cast float-to-float: NaN")]
+fn f64_nan_to_f32() {
+    f32::conv_approx(f64::NAN);
+}
+
+#[test]
+fn approx_f64_to_f32() {
+    assert_eq!(f32::conv_approx(0f64), 0f32);
+    assert_eq!(f32::conv_approx(0f64).is_sign_positive(), true);
+    assert_eq!(f32::conv_approx(-0f64).is_sign_negative(), true);
+
+    const E32: f64 = f32::EPSILON as f64;
+    assert_eq!(f32::conv_approx(1f64), 1f32);
+    assert_eq!(f32::conv_approx(1f64 + E32), 1f32 + f32::EPSILON);
+    assert_eq!(f32::conv_approx(1f64 + E32 / 2.0), 1f32);
+    assert_eq!(
+        f32::conv_approx((1f64 + E32 / 2.0).next_up()),
+        1f32.next_up()
+    );
+
+    assert_eq!(f32::conv_approx(-10f64), -10f32);
+    assert!((f32::conv_approx(1f64 / 3.0) - 1f32 / 3.0).abs() <= f32::EPSILON);
+
+    const MAX: f64 = f32::MAX as f64;
+    assert_eq!(f32::conv_approx(MAX), f32::MAX);
+    // last non-zero binary digits of mantissa are 1101, which rounds down:
+    assert_eq!(f32::conv_approx(MAX + 2f64.powi(102)), f32::MAX);
+    // last non-zero binary digits of mantissa are 1110, which rounds up:
+    assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::INFINITY);
+
+    assert_eq!(
+        f32::conv_approx(f64::INFINITY).to_bits(),
+        f32::INFINITY.to_bits()
+    );
+    assert_eq!(f32::try_conv_approx(f64::NAN), Err(Error::Range));
+}
+
+#[test]
 fn f32_to_u128_special_case() {
     let max = 0xFFFFFF00_00000000_00000000_00000000u128;
     assert_eq!(u128::try_conv_trunc(f32::MAX), Ok(max));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,44 +82,6 @@ fn approx_float_to_int() {
 }
 
 #[test]
-fn approx_f64_f32() {
-    assert_eq!(f32::conv_approx(0f64), 0f32);
-    assert_eq!(f32::conv_approx(0f64).is_sign_positive(), true);
-    assert_eq!(f32::conv_approx(-0f64).is_sign_negative(), true);
-
-    const E32: f64 = f32::EPSILON as f64;
-    assert_eq!(f32::conv_approx(1f64), 1f32);
-    assert_eq!(f32::conv_approx(1f64 + E32), 1f32 + f32::EPSILON);
-    assert_eq!(f32::conv_approx(1f64 + E32 / 2.0), 1f32);
-    assert_eq!(
-        f32::conv_approx((1f64 + E32 / 2.0).next_up()),
-        1f32.next_up()
-    );
-
-    assert_eq!(f32::conv_approx(-10f64), -10f32);
-    assert!((f32::conv_approx(1f64 / 3.0) - 1f32 / 3.0).abs() <= f32::EPSILON);
-
-    const MAX: f64 = f32::MAX as f64;
-    assert_eq!(f32::conv_approx(MAX), f32::MAX);
-    // last non-zero binary digits of mantissa are 1101, which rounds down:
-    assert_eq!(f32::conv_approx(MAX + 2f64.powi(102)), f32::MAX);
-    // last non-zero binary digits of mantissa are 1110, which rounds up:
-    assert_eq!(f32::conv_approx(MAX + 2f64.powi(103)), f32::INFINITY);
-
-    assert_eq!(
-        f32::conv_approx(f64::INFINITY).to_bits(),
-        f32::INFINITY.to_bits()
-    );
-    assert_eq!(f32::try_conv_approx(f64::NAN), Err(Error::Range));
-}
-
-#[test]
-#[should_panic(expected = "cast x: f64 to f32 (approx): range error for x = NaN")]
-fn approx_nan() {
-    f32::conv_approx(f64::NAN);
-}
-
-#[test]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_casts() {
     assert_eq!(u64::conv_nearest(13.2f32), 13);


### PR DESCRIPTION
`f64::conv(f32::NAN)` now yields `Err(Error::Range)`.

Also moved some test code and tweaked the NAN traps to improve inlining.