### PR TITLE
Remove support for Saturating, Wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
     uses `roundTiesToEven`. Unlike `as f32`, NAN still yields
     `Err(Error::Range)`. (#47)
 -   Change `Conv<f32> for f64` to trap NAN (#48)
+-   Remove support for `Saturating`, `Wrapping` (#49)
 
 ## [0.5.5] — 2026-07-08
 

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -6,31 +6,7 @@
 //! `core::num` impls for Conv.
 
 use super::*;
-use core::num::{NonZero, Saturating, Wrapping};
-
-impl<F, T: Conv<F>> Conv<Saturating<F>> for Saturating<T> {
-    #[inline]
-    fn try_conv(n: Saturating<F>) -> Result<Saturating<T>> {
-        n.0.try_cast().map(Saturating)
-    }
-
-    #[inline]
-    fn conv(n: Saturating<F>) -> Saturating<T> {
-        Saturating(n.0.cast())
-    }
-}
-
-impl<F, T: Conv<F>> Conv<Wrapping<F>> for Wrapping<T> {
-    #[inline]
-    fn try_conv(n: Wrapping<F>) -> Result<Wrapping<T>> {
-        n.0.try_cast().map(Wrapping)
-    }
-
-    #[inline]
-    fn conv(n: Wrapping<F>) -> Wrapping<T> {
-        Wrapping(n.0.cast())
-    }
-}
+use core::num::NonZero;
 
 macro_rules! impl_via_trivial {
     ($x:ty) => {

--- a/tests/core_ops_types.rs
+++ b/tests/core_ops_types.rs
@@ -12,24 +12,6 @@ fn nonzero_casts() {
 }
 
 #[test]
-fn saturating_casts() {
-    let a: Saturating<i32> = Saturating(213);
-    let b: Saturating<u128> = a.cast();
-    let c = Saturating::<u8>::conv(b);
-    let d = c.cast();
-    assert_eq!(a, d);
-}
-
-#[test]
-fn wrapping_casts() {
-    let a: Wrapping<i32> = Wrapping(213);
-    let b: Wrapping<u128> = a.cast();
-    let c = Wrapping::<u8>::conv(b);
-    let d = c.cast();
-    assert_eq!(a, d);
-}
-
-#[test]
 fn range_cast() {
     let a: Range<usize> = 10..20;
     let b: Range<u8> = a.cast();
@@ -75,18 +57,6 @@ fn nonzero_try_conv_range_errors() {
     );
     assert_eq!(
         NonZeroI8::try_conv(NonZeroU16::new(128).unwrap()),
-        Err(Error::Range)
-    );
-}
-
-#[test]
-fn wrapper_try_conv_range_errors() {
-    assert_eq!(
-        Saturating::<u8>::try_conv(Saturating(256u16)),
-        Err(Error::Range)
-    );
-    assert_eq!(
-        Wrapping::<i8>::try_conv(Wrapping(128u16)),
         Err(Error::Range)
     );
 }

--- a/tests/core_range_types.rs
+++ b/tests/core_range_types.rs
@@ -12,24 +12,6 @@ fn nonzero_casts() {
 }
 
 #[test]
-fn saturating_casts() {
-    let a: Saturating<i32> = Saturating(213);
-    let b: Saturating<u128> = a.cast();
-    let c = Saturating::<u8>::conv(b);
-    let d = c.cast();
-    assert_eq!(a, d);
-}
-
-#[test]
-fn wrapping_casts() {
-    let a: Wrapping<i32> = Wrapping(213);
-    let b: Wrapping<u128> = a.cast();
-    let c = Wrapping::<u8>::conv(b);
-    let d = c.cast();
-    assert_eq!(a, d);
-}
-
-#[test]
 fn range_cast() {
     let a: Range<usize> = (10..20).into();
     let b: Range<u8> = a.cast();


### PR DESCRIPTION
Motivation: one might logically expect casts on such types to be saturating / wrapping. These impls (added in #38) are not.

Note that such casts would contradict the "value-preserving" semantic expected by `Conv` (inherited from `From`), thus this is debatable. This may be why `From` does not offer conversions on these wrapper types.