### PR TITLE
Implement overflow of u128::MAX to f32::INFINITY

### DIFF
--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -237,8 +237,8 @@ macro_rules! impl_via_digits_check {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
                     Self::try_conv(x).unwrap_or_else(|_| {
                         panic!(
-                            "cast x: {} to {}: inexact for x = {}",
-                            stringify!($x), stringify!($y), x
+                            "cast x: {} to {}: inexact for x = {x}",
+                            stringify!($x), stringify!($y)
                         )
                     })
                 } else {
@@ -272,8 +272,8 @@ macro_rules! impl_via_digits_check_signed {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
                     Self::try_conv(x).unwrap_or_else(|_| {
                         panic!(
-                            "cast x: {} to {}: inexact for x = {}",
-                            stringify!($x), stringify!($y), x
+                            "cast x: {} to {}: inexact for x = {x}",
+                            stringify!($x), stringify!($y)
                         )
                     })
                 } else {
@@ -303,10 +303,34 @@ macro_rules! impl_via_digits_check_signed {
 
 impl_via_digits_check!(u32: f32);
 impl_via_digits_check!(u64: f32, f64);
-impl_via_digits_check!(u128: f32, f64);
+impl_via_digits_check!(u128: f64);
 impl_via_digits_check!(usize: f32, f64);
 
 impl_via_digits_check_signed!(i32: f32);
 impl_via_digits_check_signed!(i64: f32, f64);
 impl_via_digits_check_signed!(i128: f32, f64);
 impl_via_digits_check_signed!(isize: f32, f64);
+
+impl Conv<u128> for f32 {
+    #[inline]
+    fn conv(x: u128) -> Self {
+        if cfg!(any(debug_assertions, feature = "assert_digits")) {
+            Self::try_conv(x).unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
+        } else {
+            x as f32
+        }
+    }
+    #[inline]
+    fn try_conv(x: u128) -> Result<Self> {
+        if x < 0xffff_ff80_0000_0000_0000_0000_0000_0000_u128 {
+            let src_digits = 128u32.saturating_sub(x.leading_zeros() + x.trailing_zeros());
+            if src_digits <= f32::MANTISSA_DIGITS {
+                Ok(x as f32)
+            } else {
+                Err(Error::Inexact)
+            }
+        } else {
+            Ok(f32::INFINITY)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Range => write!(f, "source value not in target range"),
-            Error::Inexact => write!(f, "loss of precision or range error"),
+            Error::Inexact => write!(f, "loss of precision"),
         }
     }
 }

--- a/tests/int_to_float.rs
+++ b/tests/int_to_float.rs
@@ -23,6 +23,23 @@ fn int_to_float_exact_and_inexact() {
         Ok(18446744073709549568.0)
     );
     assert_eq!(f64::try_conv(0xFFFF_FFFF_FFFF_FC00u64), Err(Error::Inexact));
+
+    assert_eq!(
+        f32::try_conv(0xFFFFFF00_00000000_00000000_00000001_u128),
+        Err(Error::Inexact)
+    );
+}
+
+#[test]
+fn int_to_float_overflow() {
+    assert_eq!(
+        f32::try_conv(0xFFFFFF00_00000000_00000000_00000000_u128),
+        Ok(f32::MAX)
+    );
+    assert_eq!(
+        f32::try_conv(0xFFFFFF80_00000000_00000000_00000000_u128),
+        Ok(f32::INFINITY)
+    );
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,15 +60,6 @@ fn f32_max_to_u128() {
 }
 
 #[test]
-#[should_panic(
-    expected = "cast x: u128 to f32: inexact for x = 340282346638528859811704183484516925441"
-)]
-fn u128_large_to_f32() {
-    let v = 0xFFFFFF00_00000000_00000000_00000000u128 + 1;
-    f32::conv(v);
-}
-
-#[test]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn approx_float_to_int() {
     assert_eq!(i32::conv_approx(1.99f32), 1);


### PR DESCRIPTION
`u128` to `f32` is a special case of integer-to-float conversions: it can overflow.