### PR TITLE
0.6.1: pub macros impl_via_from, impl_via_trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## [0.6.1] — 2026-07-24
+
+Added:
+
+-   Add pub macros `impl_via_from!`, `impl_via_trivial!` (#54)
+
 ## [0.6.0] — 2026-07-21
 
 Fixed:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -298,22 +298,34 @@ impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, 
     }
 }
 
+/// Implement a trivial [`Conv`] infallibly
+///
+/// A trivial conversion is one which maps a type to itself.
+///
+/// # Example
+///
+/// ```
+/// struct MyInt(i32);
+///
+/// easy_cast::impl_via_trivial!(MyInt);
+/// ```
+#[macro_export]
 macro_rules! impl_via_trivial {
     ($x:ty) => {
-        impl Conv<$x> for $x {
+        impl $crate::Conv<$x> for $x {
             #[inline]
             fn conv(x: $x) -> Self {
                 x
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> $crate::Result<Self> {
                 Ok(x)
             }
         }
     };
     ($x:ty $(, $xx:tt)* $(,)?) => {
-        impl_via_trivial!($x);
-        impl_via_trivial!($($xx),*);
+        $crate::impl_via_trivial!($x);
+        $crate::impl_via_trivial!($($xx),*);
     };
 }
 

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -7,22 +7,44 @@
 
 use super::*;
 
+/// Implement [`Conv`] infallibly over a [`From`] implementation
+///
+/// # Example
+///
+/// ```
+/// struct MyInt(i32);
+///
+/// impl From<MyInt> for i32 {
+///     fn from(x: MyInt) -> i32 {
+///         x.0
+///     }
+/// }
+///
+/// impl From<MyInt> for i64 {
+///     fn from(x: MyInt) -> i64 {
+///         x.0.into()
+///     }
+/// }
+///
+/// easy_cast::impl_via_from!(MyInt: i32, i64);
+/// ```
+#[macro_export]
 macro_rules! impl_via_from {
     ($x:ty: $y:ty) => {
-        impl Conv<$x> for $y {
+        impl $crate::traits::Conv<$x> for $y {
             #[inline]
             fn conv(x: $x) -> $y {
                 <$y>::from(x)
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> $crate::Result<Self> {
                 Ok(<$y>::from(x))
             }
         }
     };
     ($x:ty: $y:ty, $($yy:ty),+) => {
-        impl_via_from!($x: $y);
-        impl_via_from!($x: $($yy),+);
+        $crate::impl_via_from!($x: $y);
+        $crate::impl_via_from!($x: $($yy),+);
     };
 }
 


### PR DESCRIPTION
These macros are useful for implementations on external types.