### PR TITLE
Add RangeError, remove Result

### DIFF
--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -5,7 +5,9 @@
 
 //! Basic impls for Conv
 
-use super::*;
+use crate::{Cast, Conv, Error};
+#[cfg(any(feature = "std", feature = "libm"))]
+use crate::{ConvFloat, RangeError};
 
 /// Implement [`Conv`] infallibly over a [`From`] implementation
 ///
@@ -37,7 +39,7 @@ macro_rules! impl_via_from {
                 <$y>::from(x)
             }
             #[inline]
-            fn try_conv(x: $x) -> $crate::Result<Self> {
+            fn try_conv(x: $x) -> ::core::result::Result<Self, $crate::Error> {
                 Ok(<$y>::from(x))
             }
         }
@@ -62,7 +64,7 @@ impl_via_from!(u64: i128, u128);
 // TODO(specialization): implement ConvApprox for arrays and tuples
 impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
     #[inline]
-    fn try_conv(ss: [S; N]) -> Result<Self> {
+    fn try_conv(ss: [S; N]) -> Result<Self, Error> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::try_conv(s)?;
@@ -82,7 +84,7 @@ impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
 #[cfg(any(feature = "std", feature = "libm"))]
 impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for [T; N] {
     #[inline]
-    fn try_conv_trunc(ss: [S; N]) -> Result<Self> {
+    fn try_conv_trunc(ss: [S; N]) -> Result<Self, RangeError> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::try_conv_trunc(s)?;
@@ -90,7 +92,7 @@ impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for 
         Ok(tt)
     }
     #[inline]
-    fn try_conv_nearest(ss: [S; N]) -> Result<Self> {
+    fn try_conv_nearest(ss: [S; N]) -> Result<Self, RangeError> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::try_conv_nearest(s)?;
@@ -98,7 +100,7 @@ impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for 
         Ok(tt)
     }
     #[inline]
-    fn try_conv_floor(ss: [S; N]) -> Result<Self> {
+    fn try_conv_floor(ss: [S; N]) -> Result<Self, RangeError> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::try_conv_floor(s)?;
@@ -106,7 +108,7 @@ impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for 
         Ok(tt)
     }
     #[inline]
-    fn try_conv_ceil(ss: [S; N]) -> Result<Self> {
+    fn try_conv_ceil(ss: [S; N]) -> Result<Self, RangeError> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
             *t = T::try_conv_ceil(s)?;
@@ -150,7 +152,7 @@ impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for 
 
 impl Conv<()> for () {
     #[inline]
-    fn try_conv(_: ()) -> Result<Self> {
+    fn try_conv(_: ()) -> Result<Self, Error> {
         Ok(())
     }
     #[inline]
@@ -158,7 +160,7 @@ impl Conv<()> for () {
 }
 impl<S0, T0: Conv<S0>> Conv<(S0,)> for (T0,) {
     #[inline]
-    fn try_conv(ss: (S0,)) -> Result<Self> {
+    fn try_conv(ss: (S0,)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?,))
     }
     #[inline]
@@ -168,7 +170,7 @@ impl<S0, T0: Conv<S0>> Conv<(S0,)> for (T0,) {
 }
 impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
     #[inline]
-    fn try_conv(ss: (S0, S1)) -> Result<Self> {
+    fn try_conv(ss: (S0, S1)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?, ss.1.try_cast()?))
     }
     #[inline]
@@ -178,7 +180,7 @@ impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
 }
 impl<S0, S1, S2, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>> Conv<(S0, S1, S2)> for (T0, T1, T2) {
     #[inline]
-    fn try_conv(ss: (S0, S1, S2)) -> Result<Self> {
+    fn try_conv(ss: (S0, S1, S2)) -> Result<Self, Error> {
         Ok((ss.0.try_cast()?, ss.1.try_cast()?, ss.2.try_cast()?))
     }
     #[inline]
@@ -190,7 +192,7 @@ impl<S0, S1, S2, S3, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>> Con
     for (T0, T1, T2, T3)
 {
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3)) -> Result<Self> {
+    fn try_conv(ss: (S0, S1, S2, S3)) -> Result<Self, Error> {
         Ok((
             ss.0.try_cast()?,
             ss.1.try_cast()?,
@@ -207,7 +209,7 @@ impl<S0, S1, S2, S3, S4, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>,
     Conv<(S0, S1, S2, S3, S4)> for (T0, T1, T2, T3, T4)
 {
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3, S4)) -> Result<Self> {
+    fn try_conv(ss: (S0, S1, S2, S3, S4)) -> Result<Self, Error> {
         Ok((
             ss.0.try_cast()?,
             ss.1.try_cast()?,
@@ -238,7 +240,7 @@ where
     T5: Conv<S5>,
 {
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self> {
+    fn try_conv(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self, Error> {
         Ok((
             ss.0.try_cast()?,
             ss.1.try_cast()?,
@@ -264,19 +266,19 @@ where
 #[cfg(any(feature = "std", feature = "libm"))]
 impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, T1) {
     #[inline]
-    fn try_conv_trunc(ss: (S0, S1)) -> Result<Self> {
+    fn try_conv_trunc(ss: (S0, S1)) -> Result<Self, RangeError> {
         Ok((T0::try_conv_trunc(ss.0)?, T1::try_conv_trunc(ss.1)?))
     }
     #[inline]
-    fn try_conv_nearest(ss: (S0, S1)) -> Result<Self> {
+    fn try_conv_nearest(ss: (S0, S1)) -> Result<Self, RangeError> {
         Ok((T0::try_conv_nearest(ss.0)?, T1::try_conv_nearest(ss.1)?))
     }
     #[inline]
-    fn try_conv_floor(ss: (S0, S1)) -> Result<Self> {
+    fn try_conv_floor(ss: (S0, S1)) -> Result<Self, RangeError> {
         Ok((T0::try_conv_floor(ss.0)?, T1::try_conv_floor(ss.1)?))
     }
     #[inline]
-    fn try_conv_ceil(ss: (S0, S1)) -> Result<Self> {
+    fn try_conv_ceil(ss: (S0, S1)) -> Result<Self, RangeError> {
         Ok((T0::try_conv_ceil(ss.0)?, T1::try_conv_ceil(ss.1)?))
     }
 
@@ -318,7 +320,7 @@ macro_rules! impl_via_trivial {
                 x
             }
             #[inline]
-            fn try_conv(x: $x) -> $crate::Result<Self> {
+            fn try_conv(x: $x) -> ::core::result::Result<Self, $crate::Error> {
                 Ok(x)
             }
         }

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -5,10 +5,12 @@
 
 //! Impls for ConvFloat
 
-use super::*;
+use crate::{Conv, ConvApprox, Error};
+#[cfg(any(feature = "std", feature = "libm"))]
+use crate::{ConvFloat, RangeError};
 
 impl Conv<f32> for f64 {
-    fn try_conv(x: f32) -> Result<Self> {
+    fn try_conv(x: f32) -> Result<Self, Error> {
         match x.is_nan() {
             false => Ok(x as f64),
             true => Err(Error::Range),
@@ -33,7 +35,7 @@ impl Conv<f32> for f64 {
 
 #[allow(clippy::manual_range_contains)]
 impl ConvApprox<f64> for f32 {
-    fn try_conv_approx(x: f64) -> Result<f32> {
+    fn try_conv_approx(x: f64) -> Result<f32, Error> {
         match x.is_nan() {
             false => Ok(x as f32),
             true => Err(Error::Range),
@@ -145,18 +147,18 @@ macro_rules! impl_float {
             }
 
             #[inline]
-            fn try_conv_trunc(x: $x) -> Result<Self> {
+            fn try_conv_trunc(x: $x) -> Result<Self, RangeError> {
                 // Tested: these limits work for $x=f32 and all $y except u128
                 const LBOUND: $x = $y::MIN as $x - 1.0;
                 const UBOUND: $x = $y::MAX as $x + 1.0;
                 if x > LBOUND && x < UBOUND {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
             #[inline]
-            fn try_conv_nearest(x: $x) -> Result<Self> {
+            fn try_conv_nearest(x: $x) -> Result<Self, RangeError> {
                 // Tested: these limits work for $x=f32 and all $y except u128
                 const LBOUND: $x = $y::MIN as $x;
                 const UBOUND: $x = $y::MAX as $x + 1.0;
@@ -164,11 +166,11 @@ macro_rules! impl_float {
                 if (LBOUND..UBOUND).contains(&x) {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
             #[inline]
-            fn try_conv_floor(x: $x) -> Result<Self> {
+            fn try_conv_floor(x: $x) -> Result<Self, RangeError> {
                 // Tested: these limits work for $x=f32 and all $y except u128
                 const LBOUND: $x = $y::MIN as $x;
                 const UBOUND: $x = $y::MAX as $x + 1.0;
@@ -176,11 +178,11 @@ macro_rules! impl_float {
                 if (LBOUND..UBOUND).contains(&x) {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
             #[inline]
-            fn try_conv_ceil(x: $x) -> Result<Self> {
+            fn try_conv_ceil(x: $x) -> Result<Self, RangeError> {
                 // Tested: these limits work for $x=f32 and all $y except u128
                 const LBOUND: $x = $y::MIN as $x;
                 const UBOUND: $x = $y::MAX as $x + 1.0;
@@ -188,15 +190,15 @@ macro_rules! impl_float {
                 if (LBOUND..UBOUND).contains(&x) {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
         }
 
         impl ConvApprox<$x> for $y {
             #[inline]
-            fn try_conv_approx(x: $x) -> Result<Self> {
-                ConvFloat::<$x>::try_conv_trunc(x)
+            fn try_conv_approx(x: $x) -> Result<Self, Error> {
+                ConvFloat::<$x>::try_conv_trunc(x).map_err(Into::into)
             }
             #[inline]
             fn conv_approx(x: $x) -> Self {
@@ -260,34 +262,34 @@ impl ConvFloat<f32> for u128 {
     }
 
     #[inline]
-    fn try_conv_trunc(x: f32) -> Result<Self> {
+    fn try_conv_trunc(x: f32) -> Result<Self, RangeError> {
         // Note: f32::MAX < u128::MAX
         if x >= 0.0 && x.is_finite() {
             Ok(x as u128)
         } else {
-            Err(Error::Range)
+            Err(RangeError)
         }
     }
     #[inline]
-    fn try_conv_nearest(x: f32) -> Result<Self> {
+    fn try_conv_nearest(x: f32) -> Result<Self, RangeError> {
         let x = x.round();
         if x >= 0.0 && x.is_finite() {
             Ok(x as u128)
         } else {
-            Err(Error::Range)
+            Err(RangeError)
         }
     }
     #[inline]
-    fn try_conv_floor(x: f32) -> Result<Self> {
+    fn try_conv_floor(x: f32) -> Result<Self, RangeError> {
         Self::try_conv_trunc(x)
     }
     #[inline]
-    fn try_conv_ceil(x: f32) -> Result<Self> {
+    fn try_conv_ceil(x: f32) -> Result<Self, RangeError> {
         let x = x.ceil();
         if x >= 0.0 && x.is_finite() {
             Ok(x as u128)
         } else {
-            Err(Error::Range)
+            Err(RangeError)
         }
     }
 }
@@ -295,8 +297,8 @@ impl ConvFloat<f32> for u128 {
 #[cfg(any(feature = "std", feature = "libm"))]
 impl ConvApprox<f32> for u128 {
     #[inline]
-    fn try_conv_approx(x: f32) -> Result<Self> {
-        ConvFloat::<f32>::try_conv_trunc(x)
+    fn try_conv_approx(x: f32) -> Result<Self, Error> {
+        ConvFloat::<f32>::try_conv_trunc(x).map_err(Into::into)
     }
     #[inline]
     fn conv_approx(x: f32) -> Self {

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -7,7 +7,7 @@
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use super::*;
+use super::{Conv, Error};
 use core::mem::size_of;
 
 macro_rules! impl_via_as_neg_check {
@@ -24,7 +24,7 @@ macro_rules! impl_via_as_neg_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 if x >= 0 {
                     Ok(x as $y)
                 } else {
@@ -60,7 +60,7 @@ macro_rules! impl_via_as_max_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 if x <= $y::MAX as $x {
                     Ok(x as $y)
                 } else {
@@ -97,7 +97,7 @@ macro_rules! impl_via_as_range_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 if $y::MIN as $x <= x && x <= $y::MAX as $x {
                     Ok(x as $y)
                 } else {
@@ -172,7 +172,7 @@ macro_rules! impl_int_generic {
             }
             #[allow(unused_comparisons)]
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 let src_is_signed = $x::MIN != 0;
                 let dst_is_signed = $y::MIN != 0;
                 if size_of::<$x>() < size_of::<$y>() {
@@ -245,7 +245,7 @@ macro_rules! impl_via_digits_check {
                 }
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 let src_ty_bits = (size_of::<$x>() * 8) as u32;
                 let src_digits = src_ty_bits.saturating_sub(x.leading_zeros() + x.trailing_zeros());
                 let dst_digits = $y::MANTISSA_DIGITS;
@@ -280,7 +280,7 @@ macro_rules! impl_via_digits_check_signed {
                 }
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self> {
+            fn try_conv(x: $x) -> Result<Self, Error> {
                 let src_ty_bits = (size_of::<$x>() * 8) as u32;
                 let src_digits = x.checked_abs()
                     .map(|y| src_ty_bits.saturating_sub(y.leading_zeros() + y.trailing_zeros()))
@@ -320,7 +320,7 @@ impl Conv<u128> for f32 {
         }
     }
     #[inline]
-    fn try_conv(x: u128) -> Result<Self> {
+    fn try_conv(x: u128) -> Result<Self, Error> {
         if x < 0xffff_ff80_0000_0000_0000_0000_0000_0000_u128 {
             let src_digits = 128u32.saturating_sub(x.leading_zeros() + x.trailing_zeros());
             if src_digits <= f32::MANTISSA_DIGITS {

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -5,7 +5,7 @@
 
 //! `core::num` impls for Conv.
 
-use super::*;
+use super::{Cast, Conv, Error};
 use core::num::NonZero;
 
 macro_rules! impl_via_trivial {
@@ -16,7 +16,7 @@ macro_rules! impl_via_trivial {
                 x
             }
             #[inline]
-            fn try_conv(x: NonZero<$x>) -> Result<Self> {
+            fn try_conv(x: NonZero<$x>) -> Result<Self, Error> {
                 Ok(x)
             }
         }
@@ -37,7 +37,7 @@ macro_rules! impl_nonzero {
     ($x:ty: $y:ty) => {
         impl Conv<NonZero<$x>> for NonZero<$y> {
             #[inline]
-            fn try_conv(n: NonZero<$x>) -> Result<NonZero<$y>> {
+            fn try_conv(n: NonZero<$x>) -> Result<NonZero<$y>, Error> {
                 let m: $y = n.get().try_cast()?;
                 // An error here should be impossible, but handling one is basically free:
                 NonZero::new(m).ok_or(Error::Range)

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -5,12 +5,12 @@
 
 //! `core::ops` impls for Conv.
 
-use super::*;
+use crate::{Cast, Conv, Error};
 use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
 impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
     #[inline]
-    fn try_conv(n: Range<F>) -> Result<Range<T>> {
+    fn try_conv(n: Range<F>) -> Result<Range<T>, Error> {
         Ok(Range {
             start: n.start.try_cast()?,
             end: n.end.try_cast()?,
@@ -28,7 +28,7 @@ impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
 
 impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
     #[inline]
-    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>> {
+    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Error> {
         let start = n.start().clone().try_cast()?;
         let end = n.end().clone().try_cast()?;
         Ok(RangeInclusive::new(start, end))
@@ -44,7 +44,7 @@ impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
 
 impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
     #[inline]
-    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>> {
+    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>, Error> {
         Ok(RangeFrom {
             start: n.start.try_cast()?,
         })
@@ -60,7 +60,7 @@ impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
 
 impl<F, T: Conv<F>> Conv<RangeTo<F>> for RangeTo<T> {
     #[inline]
-    fn try_conv(n: RangeTo<F>) -> Result<RangeTo<T>> {
+    fn try_conv(n: RangeTo<F>) -> Result<RangeTo<T>, Error> {
         Ok(RangeTo {
             end: n.end.try_cast()?,
         })
@@ -74,7 +74,7 @@ impl<F, T: Conv<F>> Conv<RangeTo<F>> for RangeTo<T> {
 
 impl<F, T: Conv<F>> Conv<RangeToInclusive<F>> for RangeToInclusive<T> {
     #[inline]
-    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>> {
+    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Error> {
         Ok(RangeToInclusive {
             end: n.end.try_cast()?,
         })

--- a/src/impl_range.rs
+++ b/src/impl_range.rs
@@ -5,12 +5,12 @@
 
 //! `core::range` impls for Conv.
 
-use super::*;
+use crate::{Cast, Conv, Error};
 use core::range::{Range, RangeFrom, RangeInclusive, RangeToInclusive};
 
 impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
     #[inline]
-    fn try_conv(n: Range<F>) -> Result<Range<T>> {
+    fn try_conv(n: Range<F>) -> Result<Range<T>, Error> {
         Ok(Range {
             start: n.start.try_cast()?,
             end: n.end.try_cast()?,
@@ -28,7 +28,7 @@ impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
 
 impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
     #[inline]
-    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>> {
+    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Error> {
         let start = n.start.clone().try_cast()?;
         let last = n.last.clone().try_cast()?;
         Ok(RangeInclusive { start, last })
@@ -44,7 +44,7 @@ impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
 
 impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
     #[inline]
-    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>> {
+    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>, Error> {
         Ok(RangeFrom {
             start: n.start.try_cast()?,
         })
@@ -60,7 +60,7 @@ impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
 
 impl<F, T: Conv<F>> Conv<RangeToInclusive<F>> for RangeToInclusive<T> {
     #[inline]
-    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>> {
+    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Error> {
         Ok(RangeToInclusive {
             last: n.last.try_cast()?,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,16 +69,60 @@ mod impl_range;
 
 pub mod traits;
 
+use core::convert::Infallible;
+
 #[doc(inline)]
 pub use traits::*;
 
+/// Source value lies outside of target type's range
+///
+/// More precisely, all values of the target type's domain are either
+/// incomparable to the source value or are closer to another value within
+/// the target type's domain than to the source value.
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RangeError;
+
+impl From<Infallible> for RangeError {
+    #[inline]
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}
+
+impl core::fmt::Display for RangeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "source value not in target range")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RangeError {}
+
 /// Error types for conversions
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Error {
     /// Source value lies outside of target type's range
+    ///
+    /// More precisely, all values of the target type's domain are either
+    /// incomparable to the source value or are closer to another value within
+    /// the target type's domain than to the source value.
     Range,
     /// Loss of precision and/or outside of target type's range
     Inexact,
+}
+
+impl From<Infallible> for Error {
+    #[inline]
+    fn from(error: Infallible) -> Self {
+        match error {}
+    }
+}
+
+impl From<RangeError> for Error {
+    #[inline]
+    fn from(_: RangeError) -> Self {
+        Self::Range
+    }
 }
 
 impl core::fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,3 @@ impl core::fmt::Display for Error {
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
-
-/// Result enum with bound [`Error`] type
-pub type Result<T> = core::result::Result<T, Error>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,9 @@
 //! # }
 //! ```
 
-use super::Result;
+use super::Error;
+#[cfg(any(feature = "std", feature = "libm"))]
+use crate::RangeError;
 
 /// Like [`From`], but supports fallible conversions
 ///
@@ -30,7 +32,7 @@ pub trait Conv<T>: Sized {
     /// Try converting from `T` to `Self`
     ///
     /// This method must fail on inexact conversions.
-    fn try_conv(v: T) -> Result<Self>;
+    fn try_conv(v: T) -> Result<Self, Error>;
 
     /// Convert from `T` to `Self`
     ///
@@ -65,7 +67,7 @@ pub trait Cast<T> {
     /// Try converting from `Self` to `T`
     ///
     /// Use this method to explicitly handle errors.
-    fn try_cast(self) -> Result<T>;
+    fn try_cast(self) -> Result<T, Error>;
 
     /// Cast from `Self` to `T`
     ///
@@ -87,7 +89,7 @@ impl<S, T: Conv<S>> Cast<T> for S {
         T::conv(self)
     }
     #[inline]
-    fn try_cast(self) -> Result<T> {
+    fn try_cast(self) -> Result<T, Error> {
         T::try_conv(self)
     }
 }
@@ -113,7 +115,7 @@ pub trait ConvApprox<T>: Sized {
     ///
     /// This method should allow approximate conversion, but fail on input not
     /// (approximately) in the target's range.
-    fn try_conv_approx(x: T) -> Result<Self>;
+    fn try_conv_approx(x: T) -> Result<Self, Error>;
 
     /// Converting from `T` to `Self`, allowing approximation of value
     ///
@@ -144,7 +146,7 @@ pub trait ConvApprox<T>: Sized {
 // TODO(specialization): implement also where T: ConvFloat<S>
 impl<S, T: Conv<S>> ConvApprox<S> for T {
     #[inline]
-    fn try_conv_approx(x: S) -> Result<Self> {
+    fn try_conv_approx(x: S) -> Result<Self, Error> {
         T::try_conv(x)
     }
     #[inline]
@@ -169,7 +171,7 @@ pub trait CastApprox<T> {
     /// Try approximate conversion from `Self` to `T`
     ///
     /// Use this method to explicitly handle errors.
-    fn try_cast_approx(self) -> Result<T>;
+    fn try_cast_approx(self) -> Result<T, Error>;
 
     /// Cast approximately from `Self` to `T`
     ///
@@ -187,7 +189,7 @@ pub trait CastApprox<T> {
 
 impl<S, T: ConvApprox<S>> CastApprox<T> for S {
     #[inline]
-    fn try_cast_approx(self) -> Result<T> {
+    fn try_cast_approx(self) -> Result<T, Error> {
         T::try_conv_approx(self)
     }
     #[inline]
@@ -220,19 +222,19 @@ pub trait ConvFloat<T>: Sized {
     /// Try converting to integer with truncation
     ///
     /// Rounds towards zero (same as `as`).
-    fn try_conv_trunc(x: T) -> Result<Self>;
+    fn try_conv_trunc(x: T) -> Result<Self, RangeError>;
     /// Try converting to the nearest integer
     ///
     /// Half-way cases are rounded away from `0`.
-    fn try_conv_nearest(x: T) -> Result<Self>;
+    fn try_conv_nearest(x: T) -> Result<Self, RangeError>;
     /// Try converting the floor to an integer
     ///
     /// Returns the largest integer less than or equal to `x`.
-    fn try_conv_floor(x: T) -> Result<Self>;
+    fn try_conv_floor(x: T) -> Result<Self, RangeError>;
     /// Try convert the ceiling to an integer
     ///
     /// Returns the smallest integer greater than or equal to `x`.
-    fn try_conv_ceil(x: T) -> Result<Self>;
+    fn try_conv_ceil(x: T) -> Result<Self, RangeError>;
 
     /// Convert to integer with truncatation
     ///
@@ -300,19 +302,19 @@ pub trait CastFloat<T> {
     /// Try converting to integer with truncation
     ///
     /// Rounds towards zero (same as `as`).
-    fn try_cast_trunc(self) -> Result<T>;
+    fn try_cast_trunc(self) -> Result<T, RangeError>;
     /// Try converting to the nearest integer
     ///
     /// Half-way cases are rounded away from `0`.
-    fn try_cast_nearest(self) -> Result<T>;
+    fn try_cast_nearest(self) -> Result<T, RangeError>;
     /// Try converting the floor to an integer
     ///
     /// Returns the largest integer less than or equal to `x`.
-    fn try_cast_floor(self) -> Result<T>;
+    fn try_cast_floor(self) -> Result<T, RangeError>;
     /// Try convert the ceiling to an integer
     ///
     /// Returns the smallest integer greater than or equal to `x`.
-    fn try_cast_ceil(self) -> Result<T>;
+    fn try_cast_ceil(self) -> Result<T, RangeError>;
 }
 
 #[cfg(any(feature = "std", feature = "libm"))]
@@ -335,19 +337,19 @@ impl<S, T: ConvFloat<S>> CastFloat<T> for S {
     }
 
     #[inline]
-    fn try_cast_trunc(self) -> Result<T> {
+    fn try_cast_trunc(self) -> Result<T, RangeError> {
         T::try_conv_trunc(self)
     }
     #[inline]
-    fn try_cast_nearest(self) -> Result<T> {
+    fn try_cast_nearest(self) -> Result<T, RangeError> {
         T::try_conv_nearest(self)
     }
     #[inline]
-    fn try_cast_floor(self) -> Result<T> {
+    fn try_cast_floor(self) -> Result<T, RangeError> {
         T::try_conv_floor(self)
     }
     #[inline]
-    fn try_cast_ceil(self) -> Result<T> {
+    fn try_cast_ceil(self) -> Result<T, RangeError> {
         T::try_conv_ceil(self)
     }
 }

--- a/tests/array_conv.rs
+++ b/tests/array_conv.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
-use easy_cast::{Error, traits::*};
+use easy_cast::{Error, RangeError, traits::*};
 
 #[test]
 fn integer_array_conversions_cover_success_and_failure() {
@@ -34,7 +34,7 @@ fn float_array_conversions_cover_all_rounding_modes() {
     );
     assert_eq!(
         <[u8; 3]>::try_conv_trunc([1.0f32, 256.0, 3.0]),
-        Err(Error::Range)
+        Err(RangeError)
     );
 }
 

--- a/tests/float_to_int.rs
+++ b/tests/float_to_int.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
-use easy_cast::{Error, traits::*};
+use easy_cast::{RangeError, traits::*};
 
 #[test]
 fn float_boundaries_for_small_integer_types() {
@@ -8,53 +8,53 @@ fn float_boundaries_for_small_integer_types() {
     assert_eq!(i8::try_conv_trunc(f32::from(i8::MAX)), Ok(i8::MAX));
     assert_eq!(
         i8::try_conv_trunc(f32::from(i8::MIN) - 1.0),
-        Err(Error::Range)
+        Err(RangeError)
     );
     assert_eq!(
         i8::try_conv_trunc(f32::from(i8::MAX) + 1.0),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(u8::try_conv_nearest(255.0f32), Ok(u8::MAX));
-    assert_eq!(u8::try_conv_nearest(256.0f32), Err(Error::Range));
+    assert_eq!(u8::try_conv_nearest(256.0f32), Err(RangeError));
 
     assert_eq!(i16::try_conv_floor(f64::from(i16::MIN)), Ok(i16::MIN));
     assert_eq!(i16::try_conv_ceil(f64::from(i16::MAX)), Ok(i16::MAX));
     assert_eq!(
         i16::try_conv_floor(f64::from(i16::MIN) - 1.0),
-        Err(Error::Range)
+        Err(RangeError)
     );
     assert_eq!(
         i16::try_conv_ceil(f64::from(i16::MAX) + 1.0),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(u32::try_conv_trunc(f64::from(u32::MAX)), Ok(u32::MAX));
     assert_eq!(
         u32::try_conv_trunc(f64::from(u32::MAX) + 1.0),
-        Err(Error::Range)
+        Err(RangeError)
     );
 }
 
 #[test]
 fn nan_and_infinity_are_range_errors_for_all_modes() {
     for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
-        assert_eq!(i8::try_conv_trunc(value), Err(Error::Range));
-        assert_eq!(i8::try_conv_nearest(value), Err(Error::Range));
-        assert_eq!(i8::try_conv_floor(value), Err(Error::Range));
-        assert_eq!(i8::try_conv_ceil(value), Err(Error::Range));
+        assert_eq!(i8::try_conv_trunc(value), Err(RangeError));
+        assert_eq!(i8::try_conv_nearest(value), Err(RangeError));
+        assert_eq!(i8::try_conv_floor(value), Err(RangeError));
+        assert_eq!(i8::try_conv_ceil(value), Err(RangeError));
 
-        assert_eq!(u128::try_conv_trunc(value), Err(Error::Range));
-        assert_eq!(u128::try_conv_nearest(value), Err(Error::Range));
-        assert_eq!(u128::try_conv_floor(value), Err(Error::Range));
-        assert_eq!(u128::try_conv_ceil(value), Err(Error::Range));
+        assert_eq!(u128::try_conv_trunc(value), Err(RangeError));
+        assert_eq!(u128::try_conv_nearest(value), Err(RangeError));
+        assert_eq!(u128::try_conv_floor(value), Err(RangeError));
+        assert_eq!(u128::try_conv_ceil(value), Err(RangeError));
     }
 
     for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-        assert_eq!(i16::try_conv_trunc(value), Err(Error::Range));
-        assert_eq!(i16::try_conv_nearest(value), Err(Error::Range));
-        assert_eq!(i16::try_conv_floor(value), Err(Error::Range));
-        assert_eq!(i16::try_conv_ceil(value), Err(Error::Range));
+        assert_eq!(i16::try_conv_trunc(value), Err(RangeError));
+        assert_eq!(i16::try_conv_nearest(value), Err(RangeError));
+        assert_eq!(i16::try_conv_floor(value), Err(RangeError));
+        assert_eq!(i16::try_conv_ceil(value), Err(RangeError));
     }
 }
 
@@ -66,8 +66,8 @@ fn f32_to_u128_special_case() {
     assert_eq!(u128::try_conv_floor(f32::MAX), Ok(max));
     assert_eq!(u128::try_conv_ceil(f32::MAX), Ok(max));
     assert_eq!(u128::try_conv_trunc(0.0f32), Ok(0u128));
-    assert_eq!(u128::try_conv_trunc(-1.0f32), Err(Error::Range));
-    assert_eq!(u128::try_conv_trunc(f32::INFINITY), Err(Error::Range));
+    assert_eq!(u128::try_conv_trunc(-1.0f32), Err(RangeError));
+    assert_eq!(u128::try_conv_trunc(f32::INFINITY), Err(RangeError));
 }
 
 #[test]


### PR DESCRIPTION
Adds `pub struct RangeError` as an alternative to `Error`.

Uses `RangeError` in `ConvFloat` and `CastFloat`. (It cannot be used in `ConvApprox` yet due to the blanket impl from `Conv`.)

Removes `Result`.