### PR TITLE
Add `generic` traits

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -9,6 +9,8 @@
 //! tool to facilitate writing conversions; [other traits](crate::traits) may be
 //! easier to use to convert values.
 
+use crate::RangeError;
+
 /// Rounding mode
 pub trait Rounding: Copy + Default {}
 
@@ -22,6 +24,40 @@ pub trait Rounding: Copy + Default {}
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Exact;
 impl Rounding for Exact {}
+
+/// Generic conversion trait for exact conversions
+///
+/// Implement this trait instead of [`Convert`] where conversions can never be
+/// inexact. This allows impls of `Convert<S, R>` to be derived for all
+/// `R: Rounding` modes.
+pub trait ConvertExact<S>: Sized {
+    /// Conversion error type
+    ///
+    /// This is either [`Infallible`](core::convert::Infallible) or
+    /// [`RangeError`].
+    type Error: Into<RangeError> + Into<crate::Error> + core::error::Error;
+
+    /// Try converting from `S` to `Self`
+    fn try_convert(s: S) -> Result<Self, Self::Error>;
+
+    /// Convert from `S` to `Self`
+    ///
+    /// This method must return the same result as [`Self::try_convert`] where
+    /// that method succeeds, but differs in the handling of errors:
+    ///
+    /// -   In debug builds the method must panic on error
+    /// -   In release builds the method may return a different value so long as
+    ///     the behaviour is well defined. This allows implementations to
+    ///     optimize to [`as` numeric casts].
+    ///
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
+    #[inline]
+    fn convert(s: S) -> Self {
+        Self::try_convert(s).unwrap_or_else(|e| {
+            panic!("Convert::convert(_) failed: {}", e);
+        })
+    }
+}
 
 /// Generic conversion trait
 ///
@@ -49,5 +85,19 @@ pub trait Convert<S, R: Rounding>: Sized {
         Self::try_convert(s).unwrap_or_else(|e| {
             panic!("Convert::convert(_) failed: {}", e);
         })
+    }
+}
+
+impl<S, T: ConvertExact<S>> Convert<S, Exact> for T {
+    type Error = T::Error;
+
+    #[inline]
+    fn try_convert(s: S) -> Result<Self, Self::Error> {
+        T::try_convert(s)
+    }
+
+    #[inline]
+    fn convert(s: S) -> Self {
+        T::convert(s)
     }
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -25,6 +25,19 @@ pub trait Rounding: Copy + Default {}
 pub struct Exact;
 impl Rounding for Exact {}
 
+/// Approximate conversion
+///
+/// Conversions may apply implementation-defined rounding when converting. The
+/// result must be close to the input value; more specifically the distance
+/// between the result and the input value should be less than the distance
+/// between the closest two representable values to the input value.
+///
+/// Example: `2.1_f32` may convert to `2_i32` or to `3_i32` (either
+/// implementation is valid so long as the behaviour is well-defined).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Approx;
+impl Rounding for Approx {}
+
 /// Generic conversion trait for exact conversions
 ///
 /// Implement this trait instead of [`Convert`] where conversions can never be
@@ -89,6 +102,20 @@ pub trait Convert<S, R: Rounding>: Sized {
 }
 
 impl<S, T: ConvertExact<S>> Convert<S, Exact> for T {
+    type Error = T::Error;
+
+    #[inline]
+    fn try_convert(s: S) -> Result<Self, Self::Error> {
+        T::try_convert(s)
+    }
+
+    #[inline]
+    fn convert(s: S) -> Self {
+        T::convert(s)
+    }
+}
+
+impl<S, T: ConvertExact<S>> Convert<S, Approx> for T {
     type Error = T::Error;
 
     #[inline]

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Generic conversion support
+//!
+//! The [`Convert`] trait is generic over rounding modes. This is provided as a
+//! tool to facilitate writing conversions; [other traits](crate::traits) may be
+//! easier to use to convert values.
+
+/// Rounding mode
+pub trait Rounding: Copy + Default {}
+
+/// Exact conversion only
+///
+/// Successful conversions using this "rounding" mode must preserve value
+/// exactly.
+///
+/// Example: `2.0_f32` may convert to `2_i32`. `2.1_f32` is not convertible to
+/// `i32`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Exact;
+impl Rounding for Exact {}
+
+/// Generic conversion trait
+///
+/// This trait is an extension over [`From`] and [`TryFrom`] for numeric casts.
+pub trait Convert<S, R: Rounding>: Sized {
+    /// Conversion error type
+    type Error: Into<crate::Error> + core::error::Error;
+
+    /// Try converting from `S` to `Self`
+    fn try_convert(s: S) -> Result<Self, Self::Error>;
+
+    /// Convert from `S` to `Self`
+    ///
+    /// This method must return the same result as [`Self::try_convert`] where
+    /// that method succeeds, but differs in the handling of errors:
+    ///
+    /// -   In debug builds the method must panic on error
+    /// -   In release builds the method may return a different value so long as
+    ///     the behaviour is well defined. This allows implementations to
+    ///     optimize to [`as` numeric casts].
+    ///
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expression
+    #[inline]
+    fn convert(s: S) -> Self {
+        Self::try_convert(s).unwrap_or_else(|e| {
+            panic!("Convert::convert(_) failed: {}", e);
+        })
+    }
+}

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -9,10 +9,14 @@
 //! tool to facilitate writing conversions; [other traits](crate::traits) may be
 //! easier to use to convert values.
 
-use crate::RangeError;
+use crate::{Error, RangeError};
+use core::convert::Infallible;
 
 /// Rounding mode
-pub trait Rounding: Copy + Default {}
+pub trait Rounding: Copy + Default {
+    /// Maximum error type
+    type MaximumError: From<Infallible> + Into<Error> + core::error::Error;
+}
 
 /// Exact conversion only
 ///
@@ -23,7 +27,9 @@ pub trait Rounding: Copy + Default {}
 /// `i32`.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Exact;
-impl Rounding for Exact {}
+impl Rounding for Exact {
+    type MaximumError = Error;
+}
 
 /// Approximate conversion
 ///
@@ -36,7 +42,9 @@ impl Rounding for Exact {}
 /// implementation is valid so long as the behaviour is well-defined).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Approx;
-impl Rounding for Approx {}
+impl Rounding for Approx {
+    type MaximumError = RangeError;
+}
 
 /// Generic conversion trait for exact conversions
 ///
@@ -46,8 +54,7 @@ impl Rounding for Approx {}
 pub trait ConvertExact<S>: Sized {
     /// Conversion error type
     ///
-    /// This is either [`Infallible`](core::convert::Infallible) or
-    /// [`RangeError`].
+    /// This is either [`Infallible`] or [`RangeError`].
     type Error: Into<RangeError> + Into<crate::Error> + core::error::Error;
 
     /// Try converting from `S` to `Self`
@@ -77,7 +84,7 @@ pub trait ConvertExact<S>: Sized {
 /// This trait is an extension over [`From`] and [`TryFrom`] for numeric casts.
 pub trait Convert<S, R: Rounding>: Sized {
     /// Conversion error type
-    type Error: Into<crate::Error> + core::error::Error;
+    type Error: Into<R::MaximumError> + core::error::Error;
 
     /// Try converting from `S` to `Self`
     fn try_convert(s: S) -> Result<Self, Self::Error>;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -5,9 +5,22 @@
 
 //! Generic conversion support
 //!
-//! The [`Convert`] trait is generic over rounding modes. This is provided as a
-//! tool to facilitate writing conversions; [other traits](crate::traits) may be
-//! easier to use to convert values.
+//! The traits of this module are more generic than the
+//! [other traits](crate::traits) provided by `easy-cast`; in particular, these
+//! traits support generality over [`Rounding`] modes and more precise error
+//! types as associated types.
+//!
+//! [`ConvertInto`] may be used instead of [`Cast`](crate::Cast) where
+//! genericity over [`Rounding`] modes is required.
+//!
+//! Conversions which can never be inexact should be implemented using
+//! [`ConvertExact`].
+//!
+//! Conversions which may apply rounding or may reject inputs not precisely
+//! representable by the target type should be implemented using [`Convert`].
+//! It is permissible to implement such conversions for multiple [`Rounding`]
+//! modes, for example an [`Approx`] conversion (which rounds inputs where
+//! required) and an [`Exact`] conversion (which rejects these inputs).
 
 use crate::{Error, RangeError};
 use core::convert::Infallible;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -46,7 +46,7 @@ impl Rounding for Approx {
     type MaximumError = RangeError;
 }
 
-/// Generic conversion trait for exact conversions
+/// Generic "from" conversion trait for exact conversions
 ///
 /// Implement this trait instead of [`Convert`] where conversions can never be
 /// inexact. This allows impls of `Convert<S, R>` to be derived for all
@@ -79,7 +79,7 @@ pub trait ConvertExact<S>: Sized {
     }
 }
 
-/// Generic conversion trait
+/// Generic "from" conversion trait
 ///
 /// This trait is an extension over [`From`] and [`TryFrom`] for numeric casts.
 pub trait Convert<S, R: Rounding>: Sized {
@@ -133,5 +133,45 @@ impl<S, T: ConvertExact<S>> Convert<S, Approx> for T {
     #[inline]
     fn convert(s: S) -> Self {
         T::convert(s)
+    }
+}
+
+/// Generic "into" conversion trait
+///
+/// This trait is like [`Into`] but for [`Convert`].
+///
+/// The [`Rounding`] mode must be specified when calling this trait's methods,
+/// for example `x.try_convert(Exact)` or `y.convert(Approx)`. In generic code
+/// (where `R: Rounding`), `z.try_convert(R::default())` may be used.
+pub trait ConvertInto<T, R: Rounding>: Sized {
+    /// Conversion error type
+    type Error: Into<R::MaximumError> + core::error::Error;
+
+    /// Try converting from `Self` to `T`
+    fn try_convert(self, mode: R) -> Result<T, Self::Error>;
+
+    /// Convert from `Self` to `T`
+    ///
+    /// This method must return the same result as [`Self::try_convert`] where
+    /// that method succeeds, but differs in the handling of errors:
+    ///
+    /// -   In debug builds the method must panic on error
+    /// -   In release builds the method may return a different value so long as
+    ///     the behaviour is well defined. This allows implementations to
+    ///     optimize to [`as` numeric casts].
+    ///
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expression
+    fn convert(self, mode: R) -> T;
+}
+
+impl<R: Rounding, S, T: Convert<S, R>> ConvertInto<T, R> for S {
+    type Error = T::Error;
+
+    fn try_convert(self, _: R) -> Result<T, Self::Error> {
+        T::try_convert(self)
+    }
+
+    fn convert(self, _: R) -> T {
+        T::convert(self)
     }
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -87,7 +87,7 @@ pub trait ConvertExact<S>: Sized {
     #[inline]
     fn convert(s: S) -> Self {
         Self::try_convert(s).unwrap_or_else(|e| {
-            panic!("Convert::convert(_) failed: {}", e);
+            panic!("ConvertExact::convert(_) failed: {}", e);
         })
     }
 }
@@ -112,7 +112,7 @@ pub trait Convert<S, R: Rounding>: Sized {
     ///     the behaviour is well defined. This allows implementations to
     ///     optimize to [`as` numeric casts].
     ///
-    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expression
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
     #[inline]
     fn convert(s: S) -> Self {
         Self::try_convert(s).unwrap_or_else(|e| {
@@ -173,7 +173,7 @@ pub trait ConvertInto<T, R: Rounding>: Sized {
     ///     the behaviour is well defined. This allows implementations to
     ///     optimize to [`as` numeric casts].
     ///
-    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expression
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
     fn convert(self, mode: R) -> T;
 }
 

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -11,7 +11,7 @@ use crate::generic::{Convert, Rounding};
 use crate::{ConvFloat, RangeError};
 use core::convert::Infallible;
 
-/// Implement [`Convert`] infallibly over a [`From`] implementation
+/// Implement [`ConvertExact`] infallibly over a [`From`] implementation
 ///
 /// # Example
 ///
@@ -32,10 +32,12 @@ use core::convert::Infallible;
 ///
 /// easy_cast::impl_via_from!(MyInt: i32, i64);
 /// ```
+///
+/// [`ConvertExact`]: crate::generic::ConvertExact
 #[macro_export]
 macro_rules! impl_via_from {
     ($x:ty: $y:ty) => {
-        impl $crate::generic::Convert<$x, $crate::generic::Exact> for $y {
+        impl $crate::generic::ConvertExact<$x> for $y {
             type Error = ::core::convert::Infallible;
 
             #[inline]
@@ -358,7 +360,7 @@ impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, 
     }
 }
 
-/// Implement a trivial [`Convert`] infallibly
+/// Implement a trivial [`ConvertExact`] infallibly
 ///
 /// A trivial conversion is one which maps a type to itself.
 ///
@@ -369,10 +371,12 @@ impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, 
 ///
 /// easy_cast::impl_via_trivial!(MyInt);
 /// ```
+///
+/// [`ConvertExact`]: crate::generic::ConvertExact
 #[macro_export]
 macro_rules! impl_via_trivial {
     ($x:ty) => {
-        impl<R: $crate::generic::Rounding> $crate::generic::Convert<$x, R> for $x {
+        impl $crate::generic::ConvertExact<$x> for $x {
             type Error = ::core::convert::Infallible;
 
             #[inline]

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -3,13 +3,15 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Basic impls for Conv
+//! Basic impls
 
-use crate::{Cast, Conv, Error};
+use crate::Error;
+use crate::generic::{Convert, Rounding};
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::{ConvFloat, RangeError};
+use core::convert::Infallible;
 
-/// Implement [`Conv`] infallibly over a [`From`] implementation
+/// Implement [`Convert`] infallibly over a [`From`] implementation
 ///
 /// # Example
 ///
@@ -33,13 +35,15 @@ use crate::{ConvFloat, RangeError};
 #[macro_export]
 macro_rules! impl_via_from {
     ($x:ty: $y:ty) => {
-        impl $crate::traits::Conv<$x> for $y {
+        impl $crate::generic::Convert<$x, $crate::generic::Exact> for $y {
+            type Error = ::core::convert::Infallible;
+
             #[inline]
-            fn conv(x: $x) -> $y {
+            fn convert(x: $x) -> $y {
                 <$y>::from(x)
             }
             #[inline]
-            fn try_conv(x: $x) -> ::core::result::Result<Self, $crate::Error> {
+            fn try_convert(x: $x) -> Result<Self, Self::Error> {
                 Ok(<$y>::from(x))
             }
         }
@@ -62,20 +66,24 @@ impl_via_from!(u64: i128, u128);
 
 // TODO(unsize): remove T: Copy + Default bound
 // TODO(specialization): implement ConvApprox for arrays and tuples
-impl<S, T: Conv<S> + Copy + Default, const N: usize> Conv<[S; N]> for [T; N] {
+impl<R: Rounding, S, T: Convert<S, R> + Copy + Default, const N: usize> Convert<[S; N], R>
+    for [T; N]
+{
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(ss: [S; N]) -> Result<Self, Error> {
+    fn try_convert(ss: [S; N]) -> Result<Self, Self::Error> {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
-            *t = T::try_conv(s)?;
+            *t = T::try_convert(s)?;
         }
         Ok(tt)
     }
     #[inline]
-    fn conv(ss: [S; N]) -> Self {
+    fn convert(ss: [S; N]) -> Self {
         let mut tt = [T::default(); N];
         for (s, t) in IntoIterator::into_iter(ss).zip(tt.iter_mut()) {
-            *t = T::conv(s);
+            *t = T::convert(s);
         }
         tt
     }
@@ -150,115 +158,165 @@ impl<S, T: ConvFloat<S> + Copy + Default, const N: usize> ConvFloat<[S; N]> for 
     }
 }
 
-impl Conv<()> for () {
+impl<R: Rounding> Convert<(), R> for () {
+    type Error = Infallible;
+
     #[inline]
-    fn try_conv(_: ()) -> Result<Self, Error> {
+    fn try_convert(_: ()) -> Result<Self, Self::Error> {
         Ok(())
     }
     #[inline]
-    fn conv(_: ()) -> Self {}
+    fn convert(_: ()) -> Self {}
 }
-impl<S0, T0: Conv<S0>> Conv<(S0,)> for (T0,) {
+impl<R: Rounding, S0, T0: Convert<S0, R>> Convert<(S0,), R> for (T0,) {
+    type Error = T0::Error;
+
     #[inline]
-    fn try_conv(ss: (S0,)) -> Result<Self, Error> {
-        Ok((ss.0.try_cast()?,))
+    fn try_convert(ss: (S0,)) -> Result<Self, Self::Error> {
+        Ok((T0::try_convert(ss.0)?,))
     }
     #[inline]
-    fn conv(ss: (S0,)) -> Self {
-        (ss.0.cast(),)
-    }
-}
-impl<S0, S1, T0: Conv<S0>, T1: Conv<S1>> Conv<(S0, S1)> for (T0, T1) {
-    #[inline]
-    fn try_conv(ss: (S0, S1)) -> Result<Self, Error> {
-        Ok((ss.0.try_cast()?, ss.1.try_cast()?))
-    }
-    #[inline]
-    fn conv(ss: (S0, S1)) -> Self {
-        (ss.0.cast(), ss.1.cast())
+    fn convert(ss: (S0,)) -> Self {
+        (T0::convert(ss.0),)
     }
 }
-impl<S0, S1, S2, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>> Conv<(S0, S1, S2)> for (T0, T1, T2) {
-    #[inline]
-    fn try_conv(ss: (S0, S1, S2)) -> Result<Self, Error> {
-        Ok((ss.0.try_cast()?, ss.1.try_cast()?, ss.2.try_cast()?))
-    }
-    #[inline]
-    fn conv(ss: (S0, S1, S2)) -> Self {
-        (ss.0.cast(), ss.1.cast(), ss.2.cast())
-    }
-}
-impl<S0, S1, S2, S3, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>> Conv<(S0, S1, S2, S3)>
-    for (T0, T1, T2, T3)
+impl<R: Rounding, S0, S1, T0: Convert<S0, R>, T1: Convert<S1, R>> Convert<(S0, S1), R>
+    for (T0, T1)
 {
+    type Error = Error;
+
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3)) -> Result<Self, Error> {
+    fn try_convert(ss: (S0, S1)) -> Result<Self, Self::Error> {
         Ok((
-            ss.0.try_cast()?,
-            ss.1.try_cast()?,
-            ss.2.try_cast()?,
-            ss.3.try_cast()?,
+            T0::try_convert(ss.0).map_err(Into::into)?,
+            T1::try_convert(ss.1).map_err(Into::into)?,
         ))
     }
     #[inline]
-    fn conv(ss: (S0, S1, S2, S3)) -> Self {
-        (ss.0.cast(), ss.1.cast(), ss.2.cast(), ss.3.cast())
+    fn convert(ss: (S0, S1)) -> Self {
+        (T0::convert(ss.0), T1::convert(ss.1))
     }
 }
-impl<S0, S1, S2, S3, S4, T0: Conv<S0>, T1: Conv<S1>, T2: Conv<S2>, T3: Conv<S3>, T4: Conv<S4>>
-    Conv<(S0, S1, S2, S3, S4)> for (T0, T1, T2, T3, T4)
+impl<R: Rounding, S0, S1, S2, T0: Convert<S0, R>, T1: Convert<S1, R>, T2: Convert<S2, R>>
+    Convert<(S0, S1, S2), R> for (T0, T1, T2)
 {
+    type Error = Error;
+
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3, S4)) -> Result<Self, Error> {
+    fn try_convert(ss: (S0, S1, S2)) -> Result<Self, Self::Error> {
         Ok((
-            ss.0.try_cast()?,
-            ss.1.try_cast()?,
-            ss.2.try_cast()?,
-            ss.3.try_cast()?,
-            ss.4.try_cast()?,
+            T0::try_convert(ss.0).map_err(Into::into)?,
+            T1::try_convert(ss.1).map_err(Into::into)?,
+            T2::try_convert(ss.2).map_err(Into::into)?,
         ))
     }
     #[inline]
-    fn conv(ss: (S0, S1, S2, S3, S4)) -> Self {
+    fn convert(ss: (S0, S1, S2)) -> Self {
+        (T0::convert(ss.0), T1::convert(ss.1), T2::convert(ss.2))
+    }
+}
+impl<
+    R: Rounding,
+    S0,
+    S1,
+    S2,
+    S3,
+    T0: Convert<S0, R>,
+    T1: Convert<S1, R>,
+    T2: Convert<S2, R>,
+    T3: Convert<S3, R>,
+> Convert<(S0, S1, S2, S3), R> for (T0, T1, T2, T3)
+{
+    type Error = Error;
+
+    #[inline]
+    fn try_convert(ss: (S0, S1, S2, S3)) -> Result<Self, Self::Error> {
+        Ok((
+            T0::try_convert(ss.0).map_err(Into::into)?,
+            T1::try_convert(ss.1).map_err(Into::into)?,
+            T2::try_convert(ss.2).map_err(Into::into)?,
+            T3::try_convert(ss.3).map_err(Into::into)?,
+        ))
+    }
+    #[inline]
+    fn convert(ss: (S0, S1, S2, S3)) -> Self {
         (
-            ss.0.cast(),
-            ss.1.cast(),
-            ss.2.cast(),
-            ss.3.cast(),
-            ss.4.cast(),
+            T0::convert(ss.0),
+            T1::convert(ss.1),
+            T2::convert(ss.2),
+            T3::convert(ss.3),
         )
     }
 }
-impl<S0, S1, S2, S3, S4, S5, T0, T1, T2, T3, T4, T5> Conv<(S0, S1, S2, S3, S4, S5)>
-    for (T0, T1, T2, T3, T4, T5)
-where
-    T0: Conv<S0>,
-    T1: Conv<S1>,
-    T2: Conv<S2>,
-    T3: Conv<S3>,
-    T4: Conv<S4>,
-    T5: Conv<S5>,
+impl<
+    R: Rounding,
+    S0,
+    S1,
+    S2,
+    S3,
+    S4,
+    T0: Convert<S0, R>,
+    T1: Convert<S1, R>,
+    T2: Convert<S2, R>,
+    T3: Convert<S3, R>,
+    T4: Convert<S4, R>,
+> Convert<(S0, S1, S2, S3, S4), R> for (T0, T1, T2, T3, T4)
 {
+    type Error = Error;
+
     #[inline]
-    fn try_conv(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self, Error> {
+    fn try_convert(ss: (S0, S1, S2, S3, S4)) -> Result<Self, Self::Error> {
         Ok((
-            ss.0.try_cast()?,
-            ss.1.try_cast()?,
-            ss.2.try_cast()?,
-            ss.3.try_cast()?,
-            ss.4.try_cast()?,
-            ss.5.try_cast()?,
+            T0::try_convert(ss.0).map_err(Into::into)?,
+            T1::try_convert(ss.1).map_err(Into::into)?,
+            T2::try_convert(ss.2).map_err(Into::into)?,
+            T3::try_convert(ss.3).map_err(Into::into)?,
+            T4::try_convert(ss.4).map_err(Into::into)?,
         ))
     }
     #[inline]
-    fn conv(ss: (S0, S1, S2, S3, S4, S5)) -> Self {
+    fn convert(ss: (S0, S1, S2, S3, S4)) -> Self {
         (
-            ss.0.cast(),
-            ss.1.cast(),
-            ss.2.cast(),
-            ss.3.cast(),
-            ss.4.cast(),
-            ss.5.cast(),
+            T0::convert(ss.0),
+            T1::convert(ss.1),
+            T2::convert(ss.2),
+            T3::convert(ss.3),
+            T4::convert(ss.4),
+        )
+    }
+}
+impl<R: Rounding, S0, S1, S2, S3, S4, S5, T0, T1, T2, T3, T4, T5>
+    Convert<(S0, S1, S2, S3, S4, S5), R> for (T0, T1, T2, T3, T4, T5)
+where
+    T0: Convert<S0, R>,
+    T1: Convert<S1, R>,
+    T2: Convert<S2, R>,
+    T3: Convert<S3, R>,
+    T4: Convert<S4, R>,
+    T5: Convert<S5, R>,
+{
+    type Error = Error;
+
+    #[inline]
+    fn try_convert(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self, Self::Error> {
+        Ok((
+            T0::try_convert(ss.0).map_err(Into::into)?,
+            T1::try_convert(ss.1).map_err(Into::into)?,
+            T2::try_convert(ss.2).map_err(Into::into)?,
+            T3::try_convert(ss.3).map_err(Into::into)?,
+            T4::try_convert(ss.4).map_err(Into::into)?,
+            T5::try_convert(ss.5).map_err(Into::into)?,
+        ))
+    }
+    #[inline]
+    fn convert(ss: (S0, S1, S2, S3, S4, S5)) -> Self {
+        (
+            T0::convert(ss.0),
+            T1::convert(ss.1),
+            T2::convert(ss.2),
+            T3::convert(ss.3),
+            T4::convert(ss.4),
+            T5::convert(ss.5),
         )
     }
 }
@@ -300,7 +358,7 @@ impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, 
     }
 }
 
-/// Implement a trivial [`Conv`] infallibly
+/// Implement a trivial [`Convert`] infallibly
 ///
 /// A trivial conversion is one which maps a type to itself.
 ///
@@ -314,13 +372,15 @@ impl<S0, S1, T0: ConvFloat<S0>, T1: ConvFloat<S1>> ConvFloat<(S0, S1)> for (T0, 
 #[macro_export]
 macro_rules! impl_via_trivial {
     ($x:ty) => {
-        impl $crate::Conv<$x> for $x {
+        impl<R: $crate::generic::Rounding> $crate::generic::Convert<$x, R> for $x {
+            type Error = ::core::convert::Infallible;
+
             #[inline]
-            fn conv(x: $x) -> Self {
+            fn convert(x: $x) -> Self {
                 x
             }
             #[inline]
-            fn try_conv(x: $x) -> ::core::result::Result<Self, $crate::Error> {
+            fn try_convert(x: $x) -> Result<Self, Self::Error> {
                 Ok(x)
             }
         }

--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -5,7 +5,6 @@
 
 //! Basic impls
 
-use crate::Error;
 use crate::generic::{Convert, Rounding};
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::{ConvFloat, RangeError};
@@ -185,7 +184,7 @@ impl<R: Rounding, S0, T0: Convert<S0, R>> Convert<(S0,), R> for (T0,) {
 impl<R: Rounding, S0, S1, T0: Convert<S0, R>, T1: Convert<S1, R>> Convert<(S0, S1), R>
     for (T0, T1)
 {
-    type Error = Error;
+    type Error = R::MaximumError;
 
     #[inline]
     fn try_convert(ss: (S0, S1)) -> Result<Self, Self::Error> {
@@ -202,7 +201,7 @@ impl<R: Rounding, S0, S1, T0: Convert<S0, R>, T1: Convert<S1, R>> Convert<(S0, S
 impl<R: Rounding, S0, S1, S2, T0: Convert<S0, R>, T1: Convert<S1, R>, T2: Convert<S2, R>>
     Convert<(S0, S1, S2), R> for (T0, T1, T2)
 {
-    type Error = Error;
+    type Error = R::MaximumError;
 
     #[inline]
     fn try_convert(ss: (S0, S1, S2)) -> Result<Self, Self::Error> {
@@ -229,7 +228,7 @@ impl<
     T3: Convert<S3, R>,
 > Convert<(S0, S1, S2, S3), R> for (T0, T1, T2, T3)
 {
-    type Error = Error;
+    type Error = R::MaximumError;
 
     #[inline]
     fn try_convert(ss: (S0, S1, S2, S3)) -> Result<Self, Self::Error> {
@@ -264,7 +263,7 @@ impl<
     T4: Convert<S4, R>,
 > Convert<(S0, S1, S2, S3, S4), R> for (T0, T1, T2, T3, T4)
 {
-    type Error = Error;
+    type Error = R::MaximumError;
 
     #[inline]
     fn try_convert(ss: (S0, S1, S2, S3, S4)) -> Result<Self, Self::Error> {
@@ -297,7 +296,7 @@ where
     T4: Convert<S4, R>,
     T5: Convert<S5, R>,
 {
-    type Error = Error;
+    type Error = R::MaximumError;
 
     #[inline]
     fn try_convert(ss: (S0, S1, S2, S3, S4, S5)) -> Result<Self, Self::Error> {

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -36,7 +36,6 @@ impl ConvertExact<f32> for f64 {
     }
 }
 
-#[allow(clippy::manual_range_contains)]
 impl Convert<f64, Approx> for f32 {
     type Error = RangeError;
 
@@ -307,7 +306,7 @@ impl Convert<f32, Approx> for u128 {
 
     #[inline]
     fn try_convert(x: f32) -> Result<Self, Self::Error> {
-        ConvFloat::<f32>::try_conv_trunc(x).map_err(Into::into)
+        ConvFloat::<f32>::try_conv_trunc(x)
     }
     #[inline]
     fn convert(x: f32) -> Self {

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -5,10 +5,10 @@
 
 //! Floating-point impls
 
+use crate::RangeError;
+use crate::generic::{Approx, Convert, ConvertExact};
 #[cfg(any(feature = "std", feature = "libm"))]
-use crate::ConvFloat;
-use crate::generic::ConvertExact;
-use crate::{ConvApprox, Error, RangeError};
+use crate::{ConvFloat, Error};
 
 impl ConvertExact<f32> for f64 {
     type Error = RangeError;
@@ -37,16 +37,18 @@ impl ConvertExact<f32> for f64 {
 }
 
 #[allow(clippy::manual_range_contains)]
-impl ConvApprox<f64> for f32 {
-    fn try_conv_approx(x: f64) -> Result<f32, Error> {
+impl Convert<f64, Approx> for f32 {
+    type Error = RangeError;
+
+    fn try_convert(x: f64) -> Result<f32, Self::Error> {
         match x.is_nan() {
             false => Ok(x as f32),
-            true => Err(Error::Range),
+            true => Err(RangeError),
         }
     }
 
     #[inline]
-    fn conv_approx(x: f64) -> f32 {
+    fn convert(x: f64) -> f32 {
         fn trap_nan(x: f64) {
             if x.is_nan() {
                 panic!("cast float-to-float: NaN")
@@ -198,13 +200,15 @@ macro_rules! impl_float {
             }
         }
 
-        impl ConvApprox<$x> for $y {
+        impl Convert<$x, Approx> for $y {
+            type Error = Error;
+
             #[inline]
-            fn try_conv_approx(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, Self::Error> {
                 ConvFloat::<$x>::try_conv_trunc(x).map_err(Into::into)
             }
             #[inline]
-            fn conv_approx(x: $x) -> Self {
+            fn convert(x: $x) -> Self {
                 ConvFloat::<$x>::conv_trunc(x)
             }
         }
@@ -298,15 +302,15 @@ impl ConvFloat<f32> for u128 {
 }
 
 #[cfg(any(feature = "std", feature = "libm"))]
-impl ConvApprox<f32> for u128 {
+impl Convert<f32, Approx> for u128 {
+    type Error = Error;
+
     #[inline]
-    fn try_conv_approx(x: f32) -> Result<Self, Error> {
+    fn try_convert(x: f32) -> Result<Self, Self::Error> {
         ConvFloat::<f32>::try_conv_trunc(x).map_err(Into::into)
     }
     #[inline]
-    fn conv_approx(x: f32) -> Self {
-        use crate::ConvFloat;
-
+    fn convert(x: f32) -> Self {
         ConvFloat::<f32>::conv_trunc(x)
     }
 }

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -7,10 +7,10 @@
 
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::ConvFloat;
-use crate::generic::{Convert, Exact};
+use crate::generic::ConvertExact;
 use crate::{ConvApprox, Error, RangeError};
 
-impl Convert<f32, Exact> for f64 {
+impl ConvertExact<f32> for f64 {
     type Error = RangeError;
 
     fn try_convert(x: f32) -> Result<Self, RangeError> {

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -5,10 +5,10 @@
 
 //! Floating-point impls
 
+#[cfg(any(feature = "std", feature = "libm"))]
+use crate::ConvFloat;
 use crate::RangeError;
 use crate::generic::{Approx, Convert, ConvertExact};
-#[cfg(any(feature = "std", feature = "libm"))]
-use crate::{ConvFloat, Error};
 
 impl ConvertExact<f32> for f64 {
     type Error = RangeError;
@@ -201,7 +201,7 @@ macro_rules! impl_float {
         }
 
         impl Convert<$x, Approx> for $y {
-            type Error = Error;
+            type Error = RangeError;
 
             #[inline]
             fn try_convert(x: $x) -> Result<Self, Self::Error> {
@@ -303,7 +303,7 @@ impl ConvFloat<f32> for u128 {
 
 #[cfg(any(feature = "std", feature = "libm"))]
 impl Convert<f32, Approx> for u128 {
-    type Error = Error;
+    type Error = RangeError;
 
     #[inline]
     fn try_convert(x: f32) -> Result<Self, Self::Error> {

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -3,22 +3,25 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Impls for ConvFloat
+//! Floating-point impls
 
-use crate::{Conv, ConvApprox, Error};
 #[cfg(any(feature = "std", feature = "libm"))]
-use crate::{ConvFloat, RangeError};
+use crate::ConvFloat;
+use crate::generic::{Convert, Exact};
+use crate::{ConvApprox, Error, RangeError};
 
-impl Conv<f32> for f64 {
-    fn try_conv(x: f32) -> Result<Self, Error> {
+impl Convert<f32, Exact> for f64 {
+    type Error = RangeError;
+
+    fn try_convert(x: f32) -> Result<Self, RangeError> {
         match x.is_nan() {
             false => Ok(x as f64),
-            true => Err(Error::Range),
+            true => Err(RangeError),
         }
     }
 
     #[inline]
-    fn conv(x: f32) -> f64 {
+    fn convert(x: f32) -> f64 {
         fn trap_nan(x: f32) {
             if x.is_nan() {
                 panic!("cast float-to-float: NaN")
@@ -302,6 +305,8 @@ impl ConvApprox<f32> for u128 {
     }
     #[inline]
     fn conv_approx(x: f32) -> Self {
+        use crate::ConvFloat;
+
         ConvFloat::<f32>::conv_trunc(x)
     }
 }

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -7,13 +7,13 @@
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use crate::generic::{Convert, Exact};
+use crate::generic::{Convert, ConvertExact, Exact};
 use crate::{Error, RangeError};
 use core::mem::size_of;
 
 macro_rules! impl_via_as_neg_check {
     ($x:ty: $y:ty) => {
-        impl Convert<$x, Exact> for $y {
+        impl ConvertExact<$x> for $y {
             type Error = RangeError;
 
             #[inline]
@@ -51,7 +51,7 @@ impl_via_as_neg_check!(i128: u128);
 // Assumption: $y::MAX is representable as $x
 macro_rules! impl_via_as_max_check {
     ($x:ty: $y:tt) => {
-        impl Convert<$x, Exact> for $y {
+        impl ConvertExact<$x> for $y {
             type Error = RangeError;
 
             #[inline]
@@ -90,7 +90,7 @@ impl_via_as_max_check!(u128: u8, u16, u32, u64);
 // Assumption: $y::MAX and $y::MIN are representable as $x
 macro_rules! impl_via_as_range_check {
     ($x:ty: $y:tt) => {
-        impl Convert<$x, Exact> for $y {
+        impl ConvertExact<$x> for $y {
             type Error = RangeError;
 
             #[inline]
@@ -126,7 +126,7 @@ impl_via_as_range_check!(i128: i8, i16, i32, i64, u8, u16, u32, u64);
 
 macro_rules! impl_int_generic {
     ($x:tt: $y:tt) => {
-        impl Convert<$x, Exact> for $y {
+        impl ConvertExact<$x> for $y {
             type Error = RangeError;
 
             #[allow(unused_comparisons)]
@@ -245,7 +245,7 @@ macro_rules! impl_via_digits_check {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    Self::try_convert(x).unwrap_or_else(|_| {
+                    <Self as Convert<_, _>>::try_convert(x).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -282,7 +282,7 @@ macro_rules! impl_via_digits_check_signed {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    Self::try_convert(x).unwrap_or_else(|_| {
+                    <Self as Convert<_, _>>::try_convert(x).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -329,7 +329,7 @@ impl Convert<u128, Exact> for f32 {
     #[inline]
     fn convert(x: u128) -> Self {
         if cfg!(any(debug_assertions, feature = "assert_digits")) {
-            Self::try_convert(x)
+            <Self as Convert<_, _>>::try_convert(x)
                 .unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
         } else {
             x as f32

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -3,18 +3,21 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! Integer impls for Conv.
+//! Integer impls.
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use super::{Conv, Error};
+use crate::generic::{Convert, Exact};
+use crate::{Error, RangeError};
 use core::mem::size_of;
 
 macro_rules! impl_via_as_neg_check {
     ($x:ty: $y:ty) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = RangeError;
+
             #[inline]
-            fn conv(x: $x) -> $y {
+            fn convert(x: $x) -> $y {
                 #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(
                     x >= 0,
@@ -24,11 +27,11 @@ macro_rules! impl_via_as_neg_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, RangeError> {
                 if x >= 0 {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
         }
@@ -48,9 +51,11 @@ impl_via_as_neg_check!(i128: u128);
 // Assumption: $y::MAX is representable as $x
 macro_rules! impl_via_as_max_check {
     ($x:ty: $y:tt) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = RangeError;
+
             #[inline]
-            fn conv(x: $x) -> $y {
+            fn convert(x: $x) -> $y {
                 #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(
                     x <= $y::MAX as $x,
@@ -60,11 +65,11 @@ macro_rules! impl_via_as_max_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, RangeError> {
                 if x <= $y::MAX as $x {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
         }
@@ -85,9 +90,11 @@ impl_via_as_max_check!(u128: u8, u16, u32, u64);
 // Assumption: $y::MAX and $y::MIN are representable as $x
 macro_rules! impl_via_as_range_check {
     ($x:ty: $y:tt) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = RangeError;
+
             #[inline]
-            fn conv(x: $x) -> $y {
+            fn convert(x: $x) -> $y {
                 #[cfg(any(debug_assertions, feature = "assert_int"))]
                 assert!(
                     $y::MIN as $x <= x && x <= $y::MAX as $x,
@@ -97,11 +104,11 @@ macro_rules! impl_via_as_range_check {
                 x as $y
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, RangeError> {
                 if $y::MIN as $x <= x && x <= $y::MAX as $x {
                     Ok(x as $y)
                 } else {
-                    Err(Error::Range)
+                    Err(RangeError)
                 }
             }
         }
@@ -119,10 +126,12 @@ impl_via_as_range_check!(i128: i8, i16, i32, i64, u8, u16, u32, u64);
 
 macro_rules! impl_int_generic {
     ($x:tt: $y:tt) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = RangeError;
+
             #[allow(unused_comparisons)]
             #[inline]
-            fn conv(x: $x) -> $y {
+            fn convert(x: $x) -> $y {
                 let src_is_signed = $x::MIN != 0;
                 let dst_is_signed = $y::MIN != 0;
                 if size_of::<$x>() < size_of::<$y>() {
@@ -172,7 +181,7 @@ macro_rules! impl_int_generic {
             }
             #[allow(unused_comparisons)]
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, Self::Error> {
                 let src_is_signed = $x::MIN != 0;
                 let dst_is_signed = $y::MIN != 0;
                 if size_of::<$x>() < size_of::<$y>() {
@@ -204,7 +213,7 @@ macro_rules! impl_int_generic {
                         }
                     }
                 }
-                Err(Error::Range)
+                Err(RangeError)
             }
         }
     };
@@ -230,11 +239,13 @@ impl_int_generic!(usize: u8, u16, u32, u64, u128);
 
 macro_rules! impl_via_digits_check {
     ($x:ty: $y:tt) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = Error;
+
             #[inline]
-            fn conv(x: $x) -> Self {
+            fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    Self::try_conv(x).unwrap_or_else(|_| {
+                    Self::try_convert(x).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -245,7 +256,7 @@ macro_rules! impl_via_digits_check {
                 }
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, Error> {
                 let src_ty_bits = (size_of::<$x>() * 8) as u32;
                 let src_digits = src_ty_bits.saturating_sub(x.leading_zeros() + x.trailing_zeros());
                 let dst_digits = $y::MANTISSA_DIGITS;
@@ -265,11 +276,13 @@ macro_rules! impl_via_digits_check {
 
 macro_rules! impl_via_digits_check_signed {
     ($x:ty: $y:tt) => {
-        impl Conv<$x> for $y {
+        impl Convert<$x, Exact> for $y {
+            type Error = Error;
+
             #[inline]
-            fn conv(x: $x) -> Self {
+            fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    Self::try_conv(x).unwrap_or_else(|_| {
+                    Self::try_convert(x).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -280,7 +293,7 @@ macro_rules! impl_via_digits_check_signed {
                 }
             }
             #[inline]
-            fn try_conv(x: $x) -> Result<Self, Error> {
+            fn try_convert(x: $x) -> Result<Self, Error> {
                 let src_ty_bits = (size_of::<$x>() * 8) as u32;
                 let src_digits = x.checked_abs()
                     .map(|y| src_ty_bits.saturating_sub(y.leading_zeros() + y.trailing_zeros()))
@@ -310,17 +323,20 @@ impl_via_digits_check_signed!(i64: f32, f64);
 impl_via_digits_check_signed!(i128: f32, f64);
 impl_via_digits_check_signed!(isize: f32, f64);
 
-impl Conv<u128> for f32 {
+impl Convert<u128, Exact> for f32 {
+    type Error = Error;
+
     #[inline]
-    fn conv(x: u128) -> Self {
+    fn convert(x: u128) -> Self {
         if cfg!(any(debug_assertions, feature = "assert_digits")) {
-            Self::try_conv(x).unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
+            Self::try_convert(x)
+                .unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
         } else {
             x as f32
         }
     }
     #[inline]
-    fn try_conv(x: u128) -> Result<Self, Error> {
+    fn try_convert(x: u128) -> Result<Self, Error> {
         if x < 0xffff_ff80_0000_0000_0000_0000_0000_0000_u128 {
             let src_digits = 128u32.saturating_sub(x.leading_zeros() + x.trailing_zeros());
             if src_digits <= f32::MANTISSA_DIGITS {

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -3,20 +3,24 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! `core::num` impls for Conv.
+//! `core::num` impls.
 
-use super::{Cast, Conv, Error};
+use crate::RangeError;
+use crate::generic::{Convert, Exact};
+use core::convert::Infallible;
 use core::num::NonZero;
 
 macro_rules! impl_via_trivial {
     ($x:ty) => {
-        impl Conv<NonZero<$x>> for NonZero<$x> {
+        impl Convert<NonZero<$x>, Exact> for NonZero<$x> {
+            type Error = Infallible;
+
             #[inline]
-            fn conv(x: NonZero<$x>) -> Self {
+            fn convert(x: NonZero<$x>) -> Self {
                 x
             }
             #[inline]
-            fn try_conv(x: NonZero<$x>) -> Result<Self, Error> {
+            fn try_convert(x: NonZero<$x>) -> Result<Self, Infallible> {
                 Ok(x)
             }
         }
@@ -34,13 +38,15 @@ impl_via_trivial!(
 );
 
 macro_rules! impl_nonzero {
-    ($x:ty: $y:ty) => {
-        impl Conv<NonZero<$x>> for NonZero<$y> {
+    ($x:ty : $y:ty) => {
+        impl Convert<NonZero<$x>, Exact> for NonZero<$y> {
+            type Error = RangeError;
+
             #[inline]
-            fn try_conv(n: NonZero<$x>) -> Result<NonZero<$y>, Error> {
-                let m: $y = n.get().try_cast()?;
+            fn try_convert(n: NonZero<$x>) -> Result<NonZero<$y>, Self::Error> {
+                let m: $y = <$y>::try_convert(n.get())?;
                 // An error here should be impossible, but handling one is basically free:
-                NonZero::new(m).ok_or(Error::Range)
+                NonZero::new(m).ok_or(RangeError)
             }
 
             // We do not implement conv since its main purpose is to allow
@@ -48,13 +54,14 @@ macro_rules! impl_nonzero {
             // we cannot omit all checks.
         }
     };
-    ($x:ty: $y:ty, $($yy:ty),+) => {
+    ($x:ty : $y:ty, $($yy:ty),+) => {
         impl_nonzero!($x: $y);
         impl_nonzero!($x: $($yy),+);
     };
 }
 
 // From impl_basic:
+// NOTE: these impls should be Infallible but this would require unsafe code
 impl_nonzero!(i8: i16, i32, i64, i128, isize);
 impl_nonzero!(i16: i32, i64, i128, isize);
 impl_nonzero!(i32: i64, i128);

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -6,13 +6,13 @@
 //! `core::num` impls.
 
 use crate::RangeError;
-use crate::generic::{Convert, Exact};
+use crate::generic::ConvertExact;
 use core::convert::Infallible;
 use core::num::NonZero;
 
 macro_rules! impl_via_trivial {
     ($x:ty) => {
-        impl Convert<NonZero<$x>, Exact> for NonZero<$x> {
+        impl ConvertExact<NonZero<$x>> for NonZero<$x> {
             type Error = Infallible;
 
             #[inline]
@@ -39,7 +39,7 @@ impl_via_trivial!(
 
 macro_rules! impl_nonzero {
     ($x:ty : $y:ty) => {
-        impl Convert<NonZero<$x>, Exact> for NonZero<$y> {
+        impl ConvertExact<NonZero<$x>> for NonZero<$y> {
             type Error = RangeError;
 
             #[inline]

--- a/src/impl_ops.rs
+++ b/src/impl_ops.rs
@@ -3,85 +3,99 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! `core::ops` impls for Conv.
+//! `core::ops` impls.
 
-use crate::{Cast, Conv, Error};
+use crate::generic::{Convert, Rounding};
 use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
 
-impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<Range<F>, R> for Range<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: Range<F>) -> Result<Range<T>, Error> {
+    fn try_convert(n: Range<F>) -> Result<Range<T>, Self::Error> {
         Ok(Range {
-            start: n.start.try_cast()?,
-            end: n.end.try_cast()?,
+            start: T::try_convert(n.start)?,
+            end: T::try_convert(n.end)?,
         })
     }
 
     #[inline]
-    fn conv(n: Range<F>) -> Range<T> {
+    fn convert(n: Range<F>) -> Range<T> {
         Range {
-            start: n.start.cast(),
-            end: n.end.cast(),
+            start: T::convert(n.start),
+            end: T::convert(n.end),
         }
     }
 }
 
-impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
+impl<R: Rounding, F: Clone, T: Convert<F, R>> Convert<RangeInclusive<F>, R> for RangeInclusive<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Error> {
-        let start = n.start().clone().try_cast()?;
-        let end = n.end().clone().try_cast()?;
+    fn try_convert(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Self::Error> {
+        let start = T::try_convert(n.start().clone())?;
+        let end = T::try_convert(n.end().clone())?;
         Ok(RangeInclusive::new(start, end))
     }
 
     #[inline]
-    fn conv(n: RangeInclusive<F>) -> RangeInclusive<T> {
-        let start = n.start().clone().cast();
-        let end = n.end().clone().cast();
+    fn convert(n: RangeInclusive<F>) -> RangeInclusive<T> {
+        let start = T::convert(n.start().clone());
+        let end = T::convert(n.end().clone());
         RangeInclusive::new(start, end)
     }
 }
 
-impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<RangeFrom<F>, R> for RangeFrom<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>, Error> {
+    fn try_convert(n: RangeFrom<F>) -> Result<RangeFrom<T>, Self::Error> {
         Ok(RangeFrom {
-            start: n.start.try_cast()?,
+            start: T::try_convert(n.start)?,
         })
     }
 
     #[inline]
-    fn conv(n: RangeFrom<F>) -> RangeFrom<T> {
+    fn convert(n: RangeFrom<F>) -> RangeFrom<T> {
         RangeFrom {
-            start: n.start.cast(),
+            start: T::convert(n.start),
         }
     }
 }
 
-impl<F, T: Conv<F>> Conv<RangeTo<F>> for RangeTo<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<RangeTo<F>, R> for RangeTo<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeTo<F>) -> Result<RangeTo<T>, Error> {
+    fn try_convert(n: RangeTo<F>) -> Result<RangeTo<T>, Self::Error> {
         Ok(RangeTo {
-            end: n.end.try_cast()?,
+            end: T::try_convert(n.end)?,
         })
     }
 
     #[inline]
-    fn conv(n: RangeTo<F>) -> RangeTo<T> {
-        RangeTo { end: n.end.cast() }
+    fn convert(n: RangeTo<F>) -> RangeTo<T> {
+        RangeTo {
+            end: T::convert(n.end),
+        }
     }
 }
 
-impl<F, T: Conv<F>> Conv<RangeToInclusive<F>> for RangeToInclusive<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<RangeToInclusive<F>, R> for RangeToInclusive<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Error> {
+    fn try_convert(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Self::Error> {
         Ok(RangeToInclusive {
-            end: n.end.try_cast()?,
+            end: T::try_convert(n.end)?,
         })
     }
 
     #[inline]
-    fn conv(n: RangeToInclusive<F>) -> RangeToInclusive<T> {
-        RangeToInclusive { end: n.end.cast() }
+    fn convert(n: RangeToInclusive<F>) -> RangeToInclusive<T> {
+        RangeToInclusive {
+            end: T::convert(n.end),
+        }
     }
 }

--- a/src/impl_range.rs
+++ b/src/impl_range.rs
@@ -3,73 +3,81 @@
 // You may obtain a copy of the License in the LICENSE-APACHE file or at:
 //     https://www.apache.org/licenses/LICENSE-2.0
 
-//! `core::range` impls for Conv.
+//! `core::range` impls.
 
-use crate::{Cast, Conv, Error};
+use crate::generic::{Convert, Rounding};
 use core::range::{Range, RangeFrom, RangeInclusive, RangeToInclusive};
 
-impl<F, T: Conv<F>> Conv<Range<F>> for Range<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<Range<F>, R> for Range<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: Range<F>) -> Result<Range<T>, Error> {
+    fn try_convert(n: Range<F>) -> Result<Range<T>, Self::Error> {
         Ok(Range {
-            start: n.start.try_cast()?,
-            end: n.end.try_cast()?,
+            start: T::try_convert(n.start)?,
+            end: T::try_convert(n.end)?,
         })
     }
 
     #[inline]
-    fn conv(n: Range<F>) -> Range<T> {
+    fn convert(n: Range<F>) -> Range<T> {
         Range {
-            start: n.start.cast(),
-            end: n.end.cast(),
+            start: T::convert(n.start),
+            end: T::convert(n.end),
         }
     }
 }
 
-impl<F: Clone, T: Conv<F>> Conv<RangeInclusive<F>> for RangeInclusive<T> {
+impl<R: Rounding, F: Clone, T: Convert<F, R>> Convert<RangeInclusive<F>, R> for RangeInclusive<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Error> {
-        let start = n.start.clone().try_cast()?;
-        let last = n.last.clone().try_cast()?;
+    fn try_convert(n: RangeInclusive<F>) -> Result<RangeInclusive<T>, Self::Error> {
+        let start = T::try_convert(n.start.clone())?;
+        let last = T::try_convert(n.last.clone())?;
         Ok(RangeInclusive { start, last })
     }
 
     #[inline]
-    fn conv(n: RangeInclusive<F>) -> RangeInclusive<T> {
-        let start = n.start.clone().cast();
-        let last = n.last.clone().cast();
+    fn convert(n: RangeInclusive<F>) -> RangeInclusive<T> {
+        let start = T::convert(n.start.clone());
+        let last = T::convert(n.last.clone());
         RangeInclusive { start, last }
     }
 }
 
-impl<F, T: Conv<F>> Conv<RangeFrom<F>> for RangeFrom<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<RangeFrom<F>, R> for RangeFrom<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeFrom<F>) -> Result<RangeFrom<T>, Error> {
+    fn try_convert(n: RangeFrom<F>) -> Result<RangeFrom<T>, Self::Error> {
         Ok(RangeFrom {
-            start: n.start.try_cast()?,
+            start: T::try_convert(n.start)?,
         })
     }
 
     #[inline]
-    fn conv(n: RangeFrom<F>) -> RangeFrom<T> {
+    fn convert(n: RangeFrom<F>) -> RangeFrom<T> {
         RangeFrom {
-            start: n.start.cast(),
+            start: T::convert(n.start),
         }
     }
 }
 
-impl<F, T: Conv<F>> Conv<RangeToInclusive<F>> for RangeToInclusive<T> {
+impl<R: Rounding, F, T: Convert<F, R>> Convert<RangeToInclusive<F>, R> for RangeToInclusive<T> {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Error> {
+    fn try_convert(n: RangeToInclusive<F>) -> Result<RangeToInclusive<T>, Self::Error> {
         Ok(RangeToInclusive {
-            last: n.last.try_cast()?,
+            last: T::try_convert(n.last)?,
         })
     }
 
     #[inline]
-    fn conv(n: RangeToInclusive<F>) -> RangeToInclusive<T> {
+    fn convert(n: RangeToInclusive<F>) -> RangeToInclusive<T> {
         RangeToInclusive {
-            last: n.last.cast(),
+            last: T::convert(n.last),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ mod impl_num;
 mod impl_ops;
 mod impl_range;
 
+pub mod generic;
+
 pub mod traits;
 
 use core::convert::Infallible;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,54 +5,74 @@
 
 //! Type conversion, success expected
 //!
+//! ## Converting values
+//!
 //! This library exists to make fallible numeric type conversions easy, without
 //! resorting to the `as` keyword.
 //!
-//! -   [`Conv`] is like [`From`], but supports fallible conversions
-//! -   [`Cast`] is to [`Conv`] what [`Into`] is to [`From`]
-//! -   [`ConvApprox`] and [`CastApprox`] support fallible, approximate conversion
-//! -   [`ConvFloat`] and [`CastFloat`] are similar, providing precise control over rounding
+//! -   Use [`Cast`] and [`Conv`] instead of [`Into`] and [`From`] for exact
+//!     conversions
+//! -   Use [`CastApprox`] and [`ConvApprox`] for approximate conversions
+//!     (rounding mode is implementation-defined just like `as`)
+//! -   Use [`CastFloat`] and [`ConvFloat`] for approximate conversions with
+//!     specified rounding mode (requires `std` or `libm` feature)
 //!
-//! If you are wondering "why not just use `as`", there are a few reasons:
+//! ### Error handling
 //!
-//! -   integer conversions may silently truncate or sign-extend which does not
-//!     preserve value
-//! -   prior to Rust 1.45.0 float-to-int conversions were not fully defined;
-//!     since this version they use saturating conversion (NaN converts to 0)
-//! -   you want some assurance (at least in debug builds) that the conversion
-//!     will preserve values correctly
+//! All trait methods have two variants:
 //!
-//! Why might you *not* want to use this library?
-//!
-//! -   You want saturating / truncating / other non-value-preserving conversion
-//! -   You want to convert non-numeric types ([`From`] supports a lot more
-//!     conversions than [`Conv`] does)!
-//! -   You want a thoroughly tested library (we're not quite there yet)
-//!
-//! ## Error handling
-//!
-//! All traits support two methods:
-//!
-//! -   `try_*` methods return a `Result` and always fail if the correct
-//!     conversion is not possible
-//! -   other methods may panic or return incorrect results
+//! -   A `try_` variant (e.g. `try_cast`) which returns a `Result` and fails if
+//!     the requested conversion is not possible.
+//! -   A "plain" variant (e.g. `cast`) which returns the same result on success
+//!     but may return a different result on error (see below).
 //!
 //! In debug builds, methods not returning `Result` must panic on failure. As
 //! with the overflow checks on Rust's standard integer arithmetic, this is
 //! considered a tool for finding logic errors. In release builds, these methods
-//! are permitted to return defined but incorrect results similar to the `as`
-//! keyword.
+//! are permitted to return a different (implementation-defined) result, usually
+//! matching the behaviour of [`as` numeric casts](https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric).
 //!
 //! If the `always_assert` feature flag is set, assertions will be turned on in
-//! all builds. Some additional feature flags are available for finer-grained
-//! control (see `Cargo.toml`).
+//! all builds (i.e. "plain" variants will panic on failure). Some additional
+//! feature flags are available for finer-grained control (see `Cargo.toml`).
 //!
-//! ## no_std support
+//! ### Example
 //!
-//! When the crate's default features are disabled (and `std` is not enabled)
-//! then the library supports `no_std`. In this case, [`ConvFloat`] and
-//! [`CastFloat`] are only available if the `libm` optional dependency is
-//! enabled.
+//! ```
+//! use easy_cast::traits::*;
+//!
+//! fn nth_root<X: CastApprox<f64>>(x: X, n: u32) {
+//!     let x = x.cast_approx();    // Into-like approximate conversion
+//!     if x < 0.0 && n % 2 == 0 {
+//!         println!("Imaginary values not supported!");
+//!         return;
+//!     }
+//!
+//!     let power = -i32::conv(n);  // From-like exact conversion
+//!     let root = x.powi(power);
+//!
+//!     println!("The {n}-th root of {x} is {root}");
+//!
+//!     // TryFrom-like approximate (nearest) conversion
+//!     if let Ok(nearest) = isize::try_conv_nearest(root) {
+//!         println!("Nearest integer: {nearest}");
+//!     }
+//! }
+//! ```
+//!
+//! ## Generic traits
+//!
+//! The [`generic`] traits support abstracting over rounding modes and tighter
+//! bounds on the `Error` type. Additionally, various blanket implementations
+//! supporting e.g. arrays, tuples and range types are implemented over these
+//! traits.
+//!
+//! It is recommended to implement the traits in [`generic`] instead of those in
+//! [`traits`] when supporting additional types.
+//!
+//! It is usually easier to use the [`traits`] traits to convert values, though
+//! these shouldn't be used in generic impls of [`generic`] traits; instead
+//! [`generic::ConvertInto`] may be used.
 //!
 //! [`TryFrom`]: core::convert::TryFrom
 //! [`TryInto`]: core::convert::TryInto

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,9 +15,10 @@
 //! # }
 //! ```
 
-use super::Error;
+use crate::Error;
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::RangeError;
+use crate::generic::{Convert, Exact};
 
 /// Like [`From`], but supports fallible conversions
 ///
@@ -28,13 +29,13 @@ use crate::RangeError;
 /// the most important numeric types are supported for now.
 ///
 /// The sister-trait [`Cast`] supports "into" style usage.
-pub trait Conv<T>: Sized {
-    /// Try converting from `T` to `Self`
+pub trait Conv<S>: Sized {
+    /// Try converting from `S` to `Self`
     ///
     /// This method must fail on inexact conversions.
-    fn try_conv(v: T) -> Result<Self, Error>;
+    fn try_conv(s: S) -> Result<Self, Error>;
 
-    /// Convert from `T` to `Self`
+    /// Convert from `S` to `Self`
     ///
     /// This method must return the same result as [`Self::try_conv`] where that
     /// method succeeds, but differs in the handling of errors:
@@ -52,10 +53,22 @@ pub trait Conv<T>: Sized {
     /// This mirrors the behaviour of Rust's overflow checks on integer
     /// arithmetic in that it is a tool for diagnosing logic errors where
     /// success is expected.
-    fn conv(v: T) -> Self {
-        Self::try_conv(v).unwrap_or_else(|e| {
+    fn conv(s: S) -> Self {
+        Self::try_conv(s).unwrap_or_else(|e| {
             panic!("Conv::conv(_) failed: {}", e);
         })
+    }
+}
+
+impl<S, T: Convert<S, Exact>> Conv<S> for T {
+    #[inline]
+    fn try_conv(s: S) -> Result<Self, Error> {
+        T::try_convert(s).map_err(Into::into)
+    }
+
+    #[inline]
+    fn conv(s: S) -> Self {
+        T::convert(s)
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,10 +15,8 @@
 //! # }
 //! ```
 
-use crate::Error;
-#[cfg(any(feature = "std", feature = "libm"))]
-use crate::RangeError;
 use crate::generic::{Approx, Convert, Exact};
+use crate::{Error, RangeError};
 
 /// Like [`From`], but supports fallible conversions
 ///
@@ -128,7 +126,7 @@ pub trait ConvApprox<S>: Sized {
     ///
     /// This method should allow approximate conversion, but fail on input not
     /// (approximately) in the target's range.
-    fn try_conv_approx(s: S) -> Result<Self, Error>;
+    fn try_conv_approx(s: S) -> Result<Self, RangeError>;
 
     /// Converting from `S` to `Self`, allowing approximation of value
     ///
@@ -158,7 +156,7 @@ pub trait ConvApprox<S>: Sized {
 
 impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
     #[inline]
-    fn try_conv_approx(s: S) -> Result<Self, Error> {
+    fn try_conv_approx(s: S) -> Result<Self, RangeError> {
         T::try_convert(s).map_err(Into::into)
     }
 
@@ -184,7 +182,7 @@ pub trait CastApprox<T> {
     /// Try approximate conversion from `Self` to `T`
     ///
     /// Use this method to explicitly handle errors.
-    fn try_cast_approx(self) -> Result<T, Error>;
+    fn try_cast_approx(self) -> Result<T, RangeError>;
 
     /// Cast approximately from `Self` to `T`
     ///
@@ -202,7 +200,7 @@ pub trait CastApprox<T> {
 
 impl<S, T: ConvApprox<S>> CastApprox<T> for S {
     #[inline]
-    fn try_cast_approx(self) -> Result<T, Error> {
+    fn try_cast_approx(self) -> Result<T, RangeError> {
         T::try_conv_approx(self)
     }
     #[inline]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -18,7 +18,7 @@
 use crate::Error;
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::RangeError;
-use crate::generic::{Convert, Exact};
+use crate::generic::{Approx, Convert, Exact};
 
 /// Like [`From`], but supports fallible conversions
 ///
@@ -119,8 +119,8 @@ impl<S, T: Conv<S>> Cast<T> for S {
 /// is required.
 ///
 /// The sister-trait [`CastApprox`] supports "into" style usage.
-pub trait ConvApprox<T>: Sized {
-    /// Try converting from `T` to `Self`, allowing approximation of value
+pub trait ConvApprox<S>: Sized {
+    /// Try converting from `S` to `Self`, allowing approximation of value
     ///
     /// This conversion may truncate excess precision not supported by the
     /// target type, so long as the *value* is approximately equal, from the
@@ -128,9 +128,9 @@ pub trait ConvApprox<T>: Sized {
     ///
     /// This method should allow approximate conversion, but fail on input not
     /// (approximately) in the target's range.
-    fn try_conv_approx(x: T) -> Result<Self, Error>;
+    fn try_conv_approx(s: S) -> Result<Self, Error>;
 
-    /// Converting from `T` to `Self`, allowing approximation of value
+    /// Converting from `S` to `Self`, allowing approximation of value
     ///
     /// This method must return the same result as [`Self::try_conv_approx`]
     /// where that method succeeds, but differs in the handling of errors:
@@ -149,22 +149,22 @@ pub trait ConvApprox<T>: Sized {
     /// arithmetic in that it is a tool for diagnosing logic errors where
     /// success is expected.
     #[inline]
-    fn conv_approx(x: T) -> Self {
-        Self::try_conv_approx(x).unwrap_or_else(|e| {
+    fn conv_approx(s: S) -> Self {
+        Self::try_conv_approx(s).unwrap_or_else(|e| {
             panic!("ConvApprox::conv_approx(_) failed: {}", e);
         })
     }
 }
 
-// TODO(specialization): implement also where T: ConvFloat<S>
-impl<S, T: Conv<S>> ConvApprox<S> for T {
+impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
     #[inline]
-    fn try_conv_approx(x: S) -> Result<Self, Error> {
-        T::try_conv(x)
+    fn try_conv_approx(s: S) -> Result<Self, Error> {
+        T::try_convert(s).map_err(Into::into)
     }
+
     #[inline]
-    fn conv_approx(x: S) -> Self {
-        T::conv(x)
+    fn conv_approx(s: S) -> Self {
+        T::convert(s)
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,13 +20,23 @@ use crate::{Error, RangeError};
 
 /// Like [`From`], but supports fallible conversions
 ///
-/// This trait is intended to be an extension over [`From`], also supporting
-/// fallible conversions of numeric types.
-/// Since Rust does not yet have stable support for handling conflicting
-/// implementations (specialization or otherwise), only conversions between
-/// the most important numeric types are supported for now.
+/// This trait is similar to [`From`], but limited to numeric conversions:
+/// -   Like [`TryFrom`] (unlike [`From`]), conversions may be *fallible*.
+///     Unlike [`TryFrom`], the [`Error`] type is fixed with precisely two
+///     variants: [`Error::Range`] and [`Error::Inexact`].
+/// -   Like [`From`], conversions must be *lossless*. For example, `Conv<f64>`
+///     is not implemented for `f32` since `f64` carries more precision; use
+///     [`ConvApprox`] instead for cases where loss-of-precision is intended.
+/// -   Like [`From`], conversions must be *value-preserving*. For example,
+///     `-1_i8` and `-1_i32` are conceptually the same value while `255_u8` is
+///     conceptually a different value, thus while `Conv<i8>` is implemented for
+///     both `i32` and `u8`, attempting to convert `-1` to `u8` will fail with
+///     [`Error::Range`].
 ///
 /// The sister-trait [`Cast`] supports "into" style usage.
+///
+/// It is recommended not to implement this trait directly but to instead
+/// implement one of the [`generic`](crate::generic) traits.
 pub trait Conv<S>: Sized {
     /// Try converting from `S` to `Self`
     ///
@@ -107,16 +117,23 @@ impl<S, T: Conv<S>> Cast<T> for S {
 
 /// Like [`From`], but for approximate numerical conversions
 ///
-/// On success, the result must be approximately the same as the input value:
-/// the difference must be smaller than the precision of the target type.
+/// Unlike [`Conv`], conversions are permitted to lose precision provided that
+/// the result is close to the input value. More precisely, the difference
+/// between the input and output values should be less than the difference
+/// between the two closest representable values in the target type.
 /// For example, one may have `i32::conv_approx(1.9f32) = 1` or
 /// `f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0) = 1.0`.
 ///
-/// Precise rounding mode should usually be truncation (round towards zero),
-/// but this is not required. Use [`ConvFloat`] where a specific rounding mode
-/// is required.
+/// The rounding mode is implementation-defined, usually aligning with the
+/// behavior of [`as` numeric casts]. Use [`ConvFloat`] instead where control
+/// over rounding modes is required.
 ///
 /// The sister-trait [`CastApprox`] supports "into" style usage.
+///
+/// It is recommended not to implement this trait directly but to instead
+/// implement one of the [`generic`](crate::generic) traits.
+///
+/// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
 pub trait ConvApprox<S>: Sized {
     /// Try converting from `S` to `Self`, allowing approximation of value
     ///
@@ -168,13 +185,16 @@ impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
 
 /// Like [`Into`], but for [`ConvApprox`]
 ///
-/// On success, the result must be approximately the same as the input value:
-/// the difference must be smaller than the precision of the target type.
-/// For example, one may have `1.9f32.cast_approx() = 1`.
+/// Unlike [`Cast`], conversions are permitted to lose precision provided that
+/// the result is close to the input value. More precisely, the difference
+/// between the input and output values should be less than the difference
+/// between the two closest representable values in the target type.
+/// For example, one may have `i32::conv_approx(1.9f32) = 1` or
+/// `f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0) = 1.0`.
 ///
-/// Precise rounding mode should usually be truncation (round towards zero),
-/// but this is not required. Use [`CastFloat`] where a specific rounding mode
-/// is required.
+/// The rounding mode is implementation-defined, usually aligning with the
+/// behavior of [`as` numeric casts]. Use [`CastFloat`] instead where control
+/// over rounding modes is required.
 ///
 /// This trait is automatically implemented for every implementation of
 /// [`ConvApprox`].

--- a/tests/float_conv.rs
+++ b/tests/float_conv.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
-use easy_cast::{Error, traits::*};
+use easy_cast::{Error, RangeError, traits::*};
 
 #[test]
 fn f64_to_f32_zero() {
@@ -55,6 +55,6 @@ fn f64_to_f32_overflow() {
 #[test]
 fn float_nan() {
     assert_eq!(f64::try_conv(f32::NAN), Err(Error::Range));
-    assert_eq!(f64::try_conv_approx(f32::NAN), Err(Error::Range));
-    assert_eq!(f32::try_conv_approx(f64::NAN), Err(Error::Range));
+    assert_eq!(f64::try_conv_approx(f32::NAN), Err(RangeError));
+    assert_eq!(f32::try_conv_approx(f64::NAN), Err(RangeError));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -69,7 +69,7 @@ fn approx_float_to_int() {
     const MAX: f64 = i32::MAX as f64;
     assert_eq!(i32::conv_approx(MAX), i32::MAX);
     assert_eq!(i32::conv_approx(MAX + 0.9), i32::MAX);
-    assert_eq!(i32::try_conv_approx(MAX + 1.0), Err(Error::Range));
+    assert_eq!(i32::try_conv_approx(MAX + 1.0), Err(RangeError));
 }
 
 #[test]


### PR DESCRIPTION
The existing trait design has some limitations, most notably that it does not support simultaneous "exact" and "approx" implementations of any conversion. The new design solves that (though doesn't yet add the missing implementations).

This PR increases complexity so I ran some quick tests on build-time (of kas); these are not significantly impacted.

This PR is minimally API-breaking (beyond the changes already made by #56); all existing value conversions should be unaffected. Porting `Conv*` impls to `generic::Convert*` is recommended but only required if derived tuple/array/range conversions are used.

Future work:

- [x] #59 
- [x] #61
- [ ] Remove `Conv*` traits? Likely not (entirely) since I have made frequent use of `T::conv(x)` in Kas (though other `Conv*` traits are not used in this way).
- [x] #62