### PR TITLE
Implement conversions for missing rounding modes

### DIFF
--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -7,8 +7,8 @@
 
 #[cfg(any(feature = "std", feature = "libm"))]
 use crate::ConvFloat;
-use crate::RangeError;
-use crate::generic::{Approx, Convert, ConvertExact};
+use crate::generic::{Approx, Convert, ConvertExact, Exact};
+use crate::{Error, RangeError};
 
 impl ConvertExact<f32> for f64 {
     type Error = RangeError;
@@ -59,6 +59,24 @@ impl Convert<f64, Approx> for f32 {
         }
 
         x as f32
+    }
+}
+
+impl Convert<f64, Exact> for f32 {
+    type Error = Error;
+
+    fn try_convert(x: f64) -> Result<f32, Self::Error> {
+        match x.is_nan() {
+            false => {
+                let y = x as f32;
+                if <f64 as ConvertExact<f32>>::try_convert(y) == Ok(x) {
+                    Ok(y)
+                } else {
+                    Err(Error::Inexact)
+                }
+            }
+            true => Err(Error::Range),
+        }
     }
 }
 

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -7,8 +7,9 @@
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use crate::generic::{Convert, ConvertExact, Exact};
+use crate::generic::{Approx, Convert, ConvertExact, ConvertInto, Exact};
 use crate::{Error, RangeError};
+use core::convert::Infallible;
 use core::mem::size_of;
 
 macro_rules! impl_via_as_neg_check {
@@ -245,7 +246,7 @@ macro_rules! impl_via_digits_check {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    <Self as Convert<_, _>>::try_convert(x).unwrap_or_else(|_| {
+                    x.try_convert(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -282,7 +283,7 @@ macro_rules! impl_via_digits_check_signed {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    <Self as Convert<_, _>>::try_convert(x).unwrap_or_else(|_| {
+                    x.try_convert(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -329,7 +330,7 @@ impl Convert<u128, Exact> for f32 {
     #[inline]
     fn convert(x: u128) -> Self {
         if cfg!(any(debug_assertions, feature = "assert_digits")) {
-            <Self as Convert<_, _>>::try_convert(x)
+            x.try_convert(Exact)
                 .unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
         } else {
             x as f32
@@ -349,3 +350,34 @@ impl Convert<u128, Exact> for f32 {
         }
     }
 }
+
+macro_rules! impl_approx {
+    ($x:ty: $y:tt) => {
+        impl Convert<$x, Approx> for $y {
+            type Error = Infallible;
+
+            #[inline]
+            fn convert(x: $x) -> Self {
+                x as $y
+            }
+            #[inline]
+            fn try_convert(x: $x) -> Result<Self, Infallible> {
+                Ok(x as $y)
+            }
+        }
+    };
+    ($x:ty: $y:tt, $($yy:tt),+) => {
+        impl_approx!($x: $y);
+        impl_approx!($x: $($yy),+);
+    };
+}
+
+impl_approx!(u32: f32);
+impl_approx!(u64: f32, f64);
+impl_approx!(u128: f32, f64);
+impl_approx!(usize: f32, f64);
+
+impl_approx!(i32: f32);
+impl_approx!(i64: f32, f64);
+impl_approx!(i128: f32, f64);
+impl_approx!(isize: f32, f64);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -270,12 +270,14 @@ pub trait ConvFloat<T>: Sized {
     /// Convert to integer with truncatation
     ///
     /// Rounds towards zero (same as `as`).
+    #[inline]
     fn conv_trunc(x: T) -> Self {
         Self::try_conv_trunc(x).unwrap_or_else(|e| panic!("ConvFloat::conv_trunc(_) failed: {}", e))
     }
     /// Convert to the nearest integer
     ///
     /// Half-way cases are rounded away from `0`.
+    #[inline]
     fn conv_nearest(x: T) -> Self {
         Self::try_conv_nearest(x)
             .unwrap_or_else(|e| panic!("ConvFloat::conv_nearest(_) failed: {}", e))
@@ -283,12 +285,14 @@ pub trait ConvFloat<T>: Sized {
     /// Convert the floor to an integer
     ///
     /// Returns the largest integer less than or equal to `x`.
+    #[inline]
     fn conv_floor(x: T) -> Self {
         Self::try_conv_floor(x).unwrap_or_else(|e| panic!("ConvFloat::conv_floor(_) failed: {}", e))
     }
     /// Convert the ceiling to an integer
     ///
     /// Returns the smallest integer greater than or equal to `x`.
+    #[inline]
     fn conv_ceil(x: T) -> Self {
         Self::try_conv_ceil(x).unwrap_or_else(|e| panic!("ConvFloat::conv_ceil(_) failed: {}", e))
     }

--- a/tests/int_to_float.rs
+++ b/tests/int_to_float.rs
@@ -31,6 +31,46 @@ fn int_to_float_exact_and_inexact() {
 }
 
 #[test]
+fn int_to_float_approx() {
+    // Duplicate the above tests but using try_conv_approx.
+    // Note that values on the right may contain more precision than f32/f64
+    // supports; the excess precision is discarded before testing for equality.
+
+    assert_eq!(f32::try_conv_approx(0u32), Ok(0.0));
+    assert_eq!(f32::try_conv_approx(1u32), Ok(1.0));
+    assert_eq!(f32::try_conv_approx(-0x00FF_FFFFi32), Ok(-16777215.0));
+    assert_eq!(f32::try_conv_approx(-0x01FF_FFFFi32), Ok(-33554431.0));
+    assert_eq!(f32::try_conv_approx(0xFFFF_FF00u32), Ok(4294967040.0));
+    assert_eq!(f32::try_conv_approx(0xFFFF_FF80u32), Ok(4294967168.0));
+
+    assert_eq!(
+        f64::try_conv_approx(-0x0000_000F_FFFF_FFFFi64),
+        Ok(-68719476735.0)
+    );
+    assert_eq!(
+        f64::try_conv_approx(-0x001F_FFFF_FFFF_FFFFi64),
+        Ok(-9007199254740991.0)
+    );
+    assert_eq!(
+        f64::try_conv_approx(-0x003F_FFFF_FFFF_FFFFi64),
+        Ok(-18014398509481983.0)
+    );
+    assert_eq!(
+        f64::try_conv_approx(0xFFFF_FFFF_FFFF_F800u64),
+        Ok(18446744073709549568.0)
+    );
+    assert_eq!(
+        f64::try_conv_approx(0xFFFF_FFFF_FFFF_FC00u64),
+        Ok(18446744073709550592.0)
+    );
+
+    assert_eq!(
+        f32::try_conv_approx(0xFFFFFF00_00000000_00000000_00000001_u128),
+        Ok(f32::MAX)
+    );
+}
+
+#[test]
 fn int_to_float_overflow() {
     assert_eq!(
         f32::try_conv(0xFFFFFF00_00000000_00000000_00000000_u128),


### PR DESCRIPTION
Int <-> float conversions are now available with `Approx` and `Exact` rounding modes.