### PR TITLE
RoundFrom, RoundInto traits

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,7 +10,7 @@
 //! traits support generality over [`Rounding`] modes and more precise error
 //! types as associated types.
 //!
-//! [`ConvertInto`] may be used instead of [`Cast`](crate::Cast) where
+//! [`RoundInto`] may be used instead of [`Cast`](crate::Cast) where
 //! genericity over [`Rounding`] modes is required.
 //!
 //! Conversions which can never be inexact should be implemented using
@@ -154,18 +154,18 @@ impl<S, T: ConvertExact<S>> Convert<S, Approx> for T {
 /// This trait is like [`Into`] but for [`Convert`].
 ///
 /// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `x.try_convert(Exact)` or `y.convert(Approx)`. In generic code
-/// (where `R: Rounding`), `z.try_convert(R::default())` may be used.
-pub trait ConvertInto<T, R: Rounding>: Sized {
+/// for example `x.try_round(Exact)` or `y.round(Approx)`. In generic code
+/// (where `R: Rounding`), `z.try_round(R::default())` may be used.
+pub trait RoundInto<T, R: Rounding>: Sized {
     /// Conversion error type
     type Error: Into<R::MaximumError> + core::error::Error;
 
     /// Try converting from `Self` to `T`
-    fn try_convert(self, mode: R) -> Result<T, Self::Error>;
+    fn try_round(self, mode: R) -> Result<T, Self::Error>;
 
     /// Convert from `Self` to `T`
     ///
-    /// This method must return the same result as [`Self::try_convert`] where
+    /// This method must return the same result as [`Self::try_round`] where
     /// that method succeeds, but differs in the handling of errors:
     ///
     /// -   In debug builds the method must panic on error
@@ -174,17 +174,17 @@ pub trait ConvertInto<T, R: Rounding>: Sized {
     ///     optimize to [`as` numeric casts].
     ///
     /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
-    fn convert(self, mode: R) -> T;
+    fn round(self, mode: R) -> T;
 }
 
-impl<R: Rounding, S, T: Convert<S, R>> ConvertInto<T, R> for S {
+impl<R: Rounding, S, T: Convert<S, R>> RoundInto<T, R> for S {
     type Error = T::Error;
 
-    fn try_convert(self, _: R) -> Result<T, Self::Error> {
+    fn try_round(self, _: R) -> Result<T, Self::Error> {
         T::try_convert(self)
     }
 
-    fn convert(self, _: R) -> T {
+    fn round(self, _: R) -> T {
         T::convert(self)
     }
 }

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -26,42 +26,10 @@
 //! [`RoundInto`]: crate::RoundInto
 //! [`RoundFrom`]: crate::RoundFrom
 
-use crate::{Error, RangeError};
-use core::convert::Infallible;
+use crate::RangeError;
 
-/// Rounding mode
-pub trait Rounding: Copy + Default {
-    /// Maximum error type
-    type MaximumError: From<Infallible> + Into<Error> + core::error::Error;
-}
-
-/// Exact conversion only
-///
-/// Successful conversions using this "rounding" mode must preserve value
-/// exactly.
-///
-/// Example: `2.0_f32` may convert to `2_i32`. `2.1_f32` is not convertible to
-/// `i32`.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Exact;
-impl Rounding for Exact {
-    type MaximumError = Error;
-}
-
-/// Approximate conversion
-///
-/// Conversions may apply implementation-defined rounding when converting. The
-/// result must be close to the input value; more specifically the distance
-/// between the result and the input value should be less than the distance
-/// between the closest two representable values to the input value.
-///
-/// Example: `2.1_f32` may convert to `2_i32` or to `3_i32` (either
-/// implementation is valid so long as the behaviour is well-defined).
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Approx;
-impl Rounding for Approx {
-    type MaximumError = RangeError;
-}
+#[doc(inline)]
+pub use crate::rounding::*;
 
 /// Generic "from" conversion trait for exact conversions
 ///
@@ -72,6 +40,8 @@ pub trait ConvertExact<S>: Sized {
     /// Conversion error type
     ///
     /// This is either [`Infallible`] or [`RangeError`].
+    ///
+    /// [`Infallible`]: std::convert::Infallible
     type Error: Into<RangeError> + Into<crate::Error> + core::error::Error;
 
     /// Try converting from `S` to `Self`

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,8 +10,9 @@
 //! traits support generality over [`Rounding`] modes and more precise error
 //! types as associated types.
 //!
-//! [`RoundInto`] may be used instead of [`Cast`](crate::Cast) where
-//! genericity over [`Rounding`] modes is required.
+//! [`RoundInto`] and [`RoundFrom`] may be used instead of
+//! [`Cast`](crate::Cast) and [`Conv`](crate::Conv) where genericity over
+//! [`Rounding`] modes is required.
 //!
 //! Conversions which can never be inexact should be implemented using
 //! [`ConvertExact`].
@@ -23,6 +24,7 @@
 //! required) and an [`Exact`] conversion (which rejects these inputs).
 //!
 //! [`RoundInto`]: crate::RoundInto
+//! [`RoundFrom`]: crate::RoundFrom
 
 use crate::{Error, RangeError};
 use core::convert::Infallible;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -21,6 +21,8 @@
 //! It is permissible to implement such conversions for multiple [`Rounding`]
 //! modes, for example an [`Approx`] conversion (which rounds inputs where
 //! required) and an [`Exact`] conversion (which rejects these inputs).
+//!
+//! [`RoundInto`]: crate::RoundInto
 
 use crate::{Error, RangeError};
 use core::convert::Infallible;
@@ -146,45 +148,5 @@ impl<S, T: ConvertExact<S>> Convert<S, Approx> for T {
     #[inline]
     fn convert(s: S) -> Self {
         T::convert(s)
-    }
-}
-
-/// Generic "into" conversion trait
-///
-/// This trait is like [`Into`] but for [`Convert`].
-///
-/// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `x.try_round(Exact)` or `y.round(Approx)`. In generic code
-/// (where `R: Rounding`), `z.try_round(R::default())` may be used.
-pub trait RoundInto<T, R: Rounding>: Sized {
-    /// Conversion error type
-    type Error: Into<R::MaximumError> + core::error::Error;
-
-    /// Try converting from `Self` to `T`
-    fn try_round(self, mode: R) -> Result<T, Self::Error>;
-
-    /// Convert from `Self` to `T`
-    ///
-    /// This method must return the same result as [`Self::try_round`] where
-    /// that method succeeds, but differs in the handling of errors:
-    ///
-    /// -   In debug builds the method must panic on error
-    /// -   In release builds the method may return a different value so long as
-    ///     the behaviour is well defined. This allows implementations to
-    ///     optimize to [`as` numeric casts].
-    ///
-    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
-    fn round(self, mode: R) -> T;
-}
-
-impl<R: Rounding, S, T: Convert<S, R>> RoundInto<T, R> for S {
-    type Error = T::Error;
-
-    fn try_round(self, _: R) -> Result<T, Self::Error> {
-        T::try_convert(self)
-    }
-
-    fn round(self, _: R) -> T {
-        T::convert(self)
     }
 }

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -7,8 +7,8 @@
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use crate::generic::{Approx, Convert, ConvertExact, Exact, RoundInto};
-use crate::{Error, RangeError};
+use crate::generic::{Approx, Convert, ConvertExact, Exact};
+use crate::{Error, RangeError, RoundInto};
 use core::convert::Infallible;
 use core::mem::size_of;
 

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -7,7 +7,7 @@
 //!
 //! See also `impl_basic` which inherits integer impls from From.
 
-use crate::generic::{Approx, Convert, ConvertExact, ConvertInto, Exact};
+use crate::generic::{Approx, Convert, ConvertExact, Exact, RoundInto};
 use crate::{Error, RangeError};
 use core::convert::Infallible;
 use core::mem::size_of;
@@ -246,7 +246,7 @@ macro_rules! impl_via_digits_check {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    x.try_convert(Exact).unwrap_or_else(|_| {
+                    x.try_round(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -283,7 +283,7 @@ macro_rules! impl_via_digits_check_signed {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    x.try_convert(Exact).unwrap_or_else(|_| {
+                    x.try_round(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -330,7 +330,7 @@ impl Convert<u128, Exact> for f32 {
     #[inline]
     fn convert(x: u128) -> Self {
         if cfg!(any(debug_assertions, feature = "assert_digits")) {
-            x.try_convert(Exact)
+            x.try_round(Exact)
                 .unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
         } else {
             x as f32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! It is usually easier to use the [`traits`] traits to convert values, though
 //! these shouldn't be used in generic impls of [`generic`] traits; instead
-//! [`generic::RoundInto`] may be used.
+//! [`RoundInto`] may be used.
 //!
 //! [`TryFrom`]: core::convert::TryFrom
 //! [`TryInto`]: core::convert::TryInto

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! It is usually easier to use the [`traits`] traits to convert values, though
 //! these shouldn't be used in generic impls of [`generic`] traits; instead
-//! [`generic::ConvertInto`] may be used.
+//! [`generic::RoundInto`] may be used.
 //!
 //! [`TryFrom`]: core::convert::TryFrom
 //! [`TryInto`]: core::convert::TryInto

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,9 @@
 //! It is recommended to implement the traits in [`generic`] instead of those in
 //! [`traits`] when supporting additional types.
 //!
-//! It is usually easier to use the [`traits`] traits to convert values, though
-//! these shouldn't be used in generic impls of [`generic`] traits; instead
-//! [`RoundInto`] may be used.
+//! It is recommended to use the [`traits`] traits to convert values. In
+//! implementations of generic traits, [`RoundFrom`] and [`RoundInto`] are
+//! usually the most appropriate traits to use.
 //!
 //! [`TryFrom`]: core::convert::TryFrom
 //! [`TryInto`]: core::convert::TryInto

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ mod impl_int;
 mod impl_num;
 mod impl_ops;
 mod impl_range;
+mod rounding;
 
 pub mod generic;
 

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE-APACHE file or at:
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+//! Rounding modes
+
+use crate::{Error, RangeError};
+use core::convert::Infallible;
+
+/// Rounding mode
+pub trait Rounding: Copy + Default {
+    /// Maximum error type
+    type MaximumError: From<Infallible> + Into<Error> + core::error::Error;
+}
+
+/// Exact conversion only
+///
+/// Successful conversions using this "rounding" mode must preserve value
+/// exactly.
+///
+/// Example: `2.0_f32` may convert to `2_i32`. `2.1_f32` is not convertible to
+/// `i32`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Exact;
+impl Rounding for Exact {
+    type MaximumError = Error;
+}
+
+/// Approximate conversion
+///
+/// Conversions may apply implementation-defined rounding when converting. The
+/// result must be close to the input value; more specifically the distance
+/// between the result and the input value should be less than the distance
+/// between the closest two representable values to the input value.
+///
+/// Example: `2.1_f32` may convert to `2_i32` or to `3_i32` (either
+/// implementation is valid so long as the behaviour is well-defined).
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Approx;
+impl Rounding for Approx {
+    type MaximumError = RangeError;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -389,6 +389,46 @@ impl<S, T: ConvFloat<S>> CastFloat<T> for S {
     }
 }
 
+/// Generic "from" conversion trait
+///
+/// This trait is like [`From`] but for [`Convert`].
+///
+/// The [`Rounding`] mode must be specified when calling this trait's methods,
+/// for example `x.try_round(Exact)` or `y.round(Approx)`. In generic code
+/// (where `R: Rounding`), `z.try_round(R::default())` may be used.
+pub trait RoundFrom<S, R: Rounding>: Sized {
+    /// Conversion error type
+    type Error: Into<R::MaximumError> + core::error::Error;
+
+    /// Try converting from `S` to `Self`
+    fn try_round(s: S, mode: R) -> Result<Self, Self::Error>;
+
+    /// Convert from `S` to `Self`
+    ///
+    /// This method must return the same result as [`Self::try_round`] where
+    /// that method succeeds, but differs in the handling of errors:
+    ///
+    /// -   In debug builds the method must panic on error
+    /// -   In release builds the method may return a different value so long as
+    ///     the behaviour is well defined. This allows implementations to
+    ///     optimize to [`as` numeric casts].
+    ///
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
+    fn round(s: S, mode: R) -> Self;
+}
+
+impl<R: Rounding, S, T: Convert<S, R>> RoundFrom<S, R> for T {
+    type Error = T::Error;
+
+    fn try_round(s: S, _: R) -> Result<Self, Self::Error> {
+        T::try_convert(s)
+    }
+
+    fn round(s: S, _: R) -> Self {
+        T::convert(s)
+    }
+}
+
 /// Generic "into" conversion trait
 ///
 /// This trait is like [`Into`] but for [`Convert`].

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -15,7 +15,7 @@
 //! # }
 //! ```
 
-use crate::generic::{Approx, Convert, Exact};
+use crate::generic::{Approx, Convert, Exact, Rounding};
 use crate::{Error, RangeError};
 
 /// Like [`From`], but supports fallible conversions
@@ -386,5 +386,45 @@ impl<S, T: ConvFloat<S>> CastFloat<T> for S {
     #[inline]
     fn try_cast_ceil(self) -> Result<T, RangeError> {
         T::try_conv_ceil(self)
+    }
+}
+
+/// Generic "into" conversion trait
+///
+/// This trait is like [`Into`] but for [`Convert`].
+///
+/// The [`Rounding`] mode must be specified when calling this trait's methods,
+/// for example `x.try_round(Exact)` or `y.round(Approx)`. In generic code
+/// (where `R: Rounding`), `z.try_round(R::default())` may be used.
+pub trait RoundInto<T, R: Rounding>: Sized {
+    /// Conversion error type
+    type Error: Into<R::MaximumError> + core::error::Error;
+
+    /// Try converting from `Self` to `T`
+    fn try_round(self, mode: R) -> Result<T, Self::Error>;
+
+    /// Convert from `Self` to `T`
+    ///
+    /// This method must return the same result as [`Self::try_round`] where
+    /// that method succeeds, but differs in the handling of errors:
+    ///
+    /// -   In debug builds the method must panic on error
+    /// -   In release builds the method may return a different value so long as
+    ///     the behaviour is well defined. This allows implementations to
+    ///     optimize to [`as` numeric casts].
+    ///
+    /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions
+    fn round(self, mode: R) -> T;
+}
+
+impl<R: Rounding, S, T: Convert<S, R>> RoundInto<T, R> for S {
+    type Error = T::Error;
+
+    fn try_round(self, _: R) -> Result<T, Self::Error> {
+        T::try_convert(self)
+    }
+
+    fn round(self, _: R) -> T {
+        T::convert(self)
     }
 }


### PR DESCRIPTION
Trait `RoundFrom` is essentially a duplicate of `generic::Convert` with a slightly different API (these will be deduplicated later). `ConvertInto` is renamed to `RoundInto`.

These two traits form the new user-interface for when control over rounding modes is required.