### PR TITLE
Add assoc Error type to Conv/Cast traits

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -22,8 +22,8 @@ use crate::{Error, RangeError};
 ///
 /// This trait is similar to [`From`], but limited to numeric conversions:
 /// -   Like [`TryFrom`] (unlike [`From`]), conversions may be *fallible*.
-///     Unlike [`TryFrom`], the [`Error`] type is fixed with precisely two
-///     variants: [`Error::Range`] and [`Error::Inexact`].
+///     Unlike [`TryFrom`], precisely two failure modes are allowed:
+///     domain ([`Error::Range`]) and loss-of-precision ([`Error::Inexact`]).
 /// -   Like [`From`], conversions must be *lossless*. For example, `Conv<f64>`
 ///     is not implemented for `f32` since `f64` carries more precision; use
 ///     [`ConvApprox`] instead for cases where loss-of-precision is intended.
@@ -31,17 +31,20 @@ use crate::{Error, RangeError};
 ///     `-1_i8` and `-1_i32` are conceptually the same value while `255_u8` is
 ///     conceptually a different value, thus while `Conv<i8>` is implemented for
 ///     both `i32` and `u8`, attempting to convert `-1` to `u8` will fail with
-///     [`Error::Range`].
+///     [`RangeError`].
 ///
 /// The sister-trait [`Cast`] supports "into" style usage.
 ///
 /// It is recommended not to implement this trait directly but to instead
 /// implement one of the [`generic`](crate::generic) traits.
 pub trait Conv<S>: Sized {
+    /// Conversion error type
+    type Error: Into<Error> + core::error::Error;
+
     /// Try converting from `S` to `Self`
     ///
     /// This method must fail on inexact conversions.
-    fn try_conv(s: S) -> Result<Self, Error>;
+    fn try_conv(s: S) -> Result<Self, Self::Error>;
 
     /// Convert from `S` to `Self`
     ///
@@ -69,9 +72,11 @@ pub trait Conv<S>: Sized {
 }
 
 impl<S, T: Convert<S, Exact>> Conv<S> for T {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv(s: S) -> Result<Self, Error> {
-        T::try_convert(s).map_err(Into::into)
+    fn try_conv(s: S) -> Result<Self, Self::Error> {
+        T::try_convert(s)
     }
 
     #[inline]
@@ -85,10 +90,13 @@ impl<S, T: Convert<S, Exact>> Conv<S> for T {
 /// This trait is automatically implemented for every implementation of
 /// [`Conv`].
 pub trait Cast<T> {
+    /// Conversion error type
+    type Error: Into<Error> + core::error::Error;
+
     /// Try converting from `Self` to `T`
     ///
     /// Use this method to explicitly handle errors.
-    fn try_cast(self) -> Result<T, Error>;
+    fn try_cast(self) -> Result<T, Self::Error>;
 
     /// Cast from `Self` to `T`
     ///
@@ -105,12 +113,14 @@ pub trait Cast<T> {
 }
 
 impl<S, T: Conv<S>> Cast<T> for S {
+    type Error = T::Error;
+
     #[inline]
     fn cast(self) -> T {
         T::conv(self)
     }
     #[inline]
-    fn try_cast(self) -> Result<T, Error> {
+    fn try_cast(self) -> Result<T, Self::Error> {
         T::try_conv(self)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -134,6 +134,8 @@ impl<S, T: Conv<S>> Cast<T> for S {
 /// For example, one may have `i32::conv_approx(1.9f32) = 1` or
 /// `f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0) = 1.0`.
 ///
+/// Only one failure mode is allowed: domain ([`RangeError`]).
+///
 /// The rounding mode is implementation-defined, usually aligning with the
 /// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`RoundInto`] with
 /// an explicit rounding mode (e.g. [`generic::Nearest`](crate::generic::Nearest))
@@ -146,6 +148,9 @@ impl<S, T: Conv<S>> Cast<T> for S {
 ///
 /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
 pub trait ConvApprox<S>: Sized {
+    /// Conversion error type
+    type Error: Into<RangeError> + core::error::Error;
+
     /// Try converting from `S` to `Self`, allowing approximation of value
     ///
     /// This conversion may truncate excess precision not supported by the
@@ -154,7 +159,7 @@ pub trait ConvApprox<S>: Sized {
     ///
     /// This method should allow approximate conversion, but fail on input not
     /// (approximately) in the target's range.
-    fn try_conv_approx(s: S) -> Result<Self, RangeError>;
+    fn try_conv_approx(s: S) -> Result<Self, Self::Error>;
 
     /// Converting from `S` to `Self`, allowing approximation of value
     ///
@@ -183,9 +188,11 @@ pub trait ConvApprox<S>: Sized {
 }
 
 impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
+    type Error = T::Error;
+
     #[inline]
-    fn try_conv_approx(s: S) -> Result<Self, RangeError> {
-        T::try_convert(s).map_err(Into::into)
+    fn try_conv_approx(s: S) -> Result<Self, Self::Error> {
+        T::try_convert(s)
     }
 
     #[inline]
@@ -211,10 +218,13 @@ impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
 /// This trait is automatically implemented for every implementation of
 /// [`ConvApprox`].
 pub trait CastApprox<T> {
+    /// Conversion error type
+    type Error: Into<RangeError> + core::error::Error;
+
     /// Try approximate conversion from `Self` to `T`
     ///
     /// Use this method to explicitly handle errors.
-    fn try_cast_approx(self) -> Result<T, RangeError>;
+    fn try_cast_approx(self) -> Result<T, Self::Error>;
 
     /// Cast approximately from `Self` to `T`
     ///
@@ -231,8 +241,10 @@ pub trait CastApprox<T> {
 }
 
 impl<S, T: ConvApprox<S>> CastApprox<T> for S {
+    type Error = T::Error;
+
     #[inline]
-    fn try_cast_approx(self) -> Result<T, RangeError> {
+    fn try_cast_approx(self) -> Result<T, Self::Error> {
         T::try_conv_approx(self)
     }
     #[inline]

--- a/tests/array_conv.rs
+++ b/tests/array_conv.rs
@@ -2,12 +2,12 @@
 
 use easy_cast::generic::{Ceil, Floor, Nearest, Trunc};
 use easy_cast::traits::*;
-use easy_cast::{Error, RangeError, RoundFrom};
+use easy_cast::{RangeError, RoundFrom};
 
 #[test]
 fn integer_array_conversions_cover_success_and_failure() {
     assert_eq!(<[u8; 4]>::try_conv([0u32, 1, 255, 42]), Ok([0, 1, 255, 42]));
-    assert_eq!(<[u8; 4]>::try_conv([0u32, 1, 256, 42]), Err(Error::Range));
+    assert_eq!(<[u8; 4]>::try_conv([0u32, 1, 256, 42]), Err(RangeError));
 }
 
 #[test]

--- a/tests/core_ops_types.rs
+++ b/tests/core_ops_types.rs
@@ -1,6 +1,6 @@
 use core::num::*;
 use core::ops::{Range, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
-use easy_cast::{Error, traits::*};
+use easy_cast::{RangeError, traits::*};
 
 #[test]
 fn nonzero_casts() {
@@ -53,18 +53,18 @@ fn range_to_inclusive_cast() {
 fn nonzero_try_conv_range_errors() {
     assert_eq!(
         NonZeroU8::try_conv(NonZeroI16::new(-1).unwrap()),
-        Err(Error::Range)
+        Err(RangeError)
     );
     assert_eq!(
         NonZeroI8::try_conv(NonZeroU16::new(128).unwrap()),
-        Err(Error::Range)
+        Err(RangeError)
     );
 }
 
 #[test]
 fn range_try_conv_boundary_checks() {
     assert_eq!(Range::<u8>::try_conv(0u32..255u32), Ok(0u8..255u8));
-    assert_eq!(Range::<u8>::try_conv(0u32..256u32), Err(Error::Range));
+    assert_eq!(Range::<u8>::try_conv(0u32..256u32), Err(RangeError));
 
     assert_eq!(
         RangeInclusive::<u8>::try_conv(0u32..=255u32),
@@ -72,18 +72,15 @@ fn range_try_conv_boundary_checks() {
     );
     assert_eq!(
         RangeInclusive::<u8>::try_conv(0u32..=256u32),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(RangeFrom::<u8>::try_conv(10u32..), Ok(10u8..));
-    assert_eq!(RangeFrom::<u8>::try_conv(256u32..), Err(Error::Range));
+    assert_eq!(RangeFrom::<u8>::try_conv(256u32..), Err(RangeError));
 
     assert_eq!(RangeTo::<u8>::try_conv(..255u32), Ok(..255u8));
-    assert_eq!(RangeTo::<u8>::try_conv(..256u32), Err(Error::Range));
+    assert_eq!(RangeTo::<u8>::try_conv(..256u32), Err(RangeError));
 
     assert_eq!(RangeToInclusive::<u8>::try_conv(..=255u32), Ok(..=255u8));
-    assert_eq!(
-        RangeToInclusive::<u8>::try_conv(..=256u32),
-        Err(Error::Range)
-    );
+    assert_eq!(RangeToInclusive::<u8>::try_conv(..=256u32), Err(RangeError));
 }

--- a/tests/core_range_types.rs
+++ b/tests/core_range_types.rs
@@ -1,6 +1,6 @@
 use core::num::*;
 use core::range::{Range, RangeFrom, RangeInclusive, RangeToInclusive};
-use easy_cast::{Error, traits::*};
+use easy_cast::{RangeError, traits::*};
 
 #[test]
 fn nonzero_casts() {
@@ -50,7 +50,7 @@ fn range_try_conv_boundary_checks() {
     );
     assert_eq!(
         Range::<u8>::try_conv((0u32..256u32).into()),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(
@@ -59,7 +59,7 @@ fn range_try_conv_boundary_checks() {
     );
     assert_eq!(
         RangeInclusive::<u8>::try_conv((0u32..=256u32).into()),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(
@@ -68,7 +68,7 @@ fn range_try_conv_boundary_checks() {
     );
     assert_eq!(
         RangeFrom::<u8>::try_conv((256u32..).into()),
-        Err(Error::Range)
+        Err(RangeError)
     );
 
     assert_eq!(
@@ -77,6 +77,6 @@ fn range_try_conv_boundary_checks() {
     );
     assert_eq!(
         RangeToInclusive::<u8>::try_conv((..=256u32).into()),
-        Err(Error::Range)
+        Err(RangeError)
     );
 }

--- a/tests/float_conv.rs
+++ b/tests/float_conv.rs
@@ -1,6 +1,6 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
-use easy_cast::{Error, RangeError, traits::*};
+use easy_cast::{RangeError, traits::*};
 
 #[test]
 fn f64_to_f32_zero() {
@@ -54,7 +54,7 @@ fn f64_to_f32_overflow() {
 
 #[test]
 fn float_nan() {
-    assert_eq!(f64::try_conv(f32::NAN), Err(Error::Range));
+    assert_eq!(f64::try_conv(f32::NAN), Err(RangeError));
     assert_eq!(f64::try_conv_approx(f32::NAN), Err(RangeError));
     assert_eq!(f32::try_conv_approx(f64::NAN), Err(RangeError));
 }

--- a/tests/int_conv.rs
+++ b/tests/int_conv.rs
@@ -1,11 +1,11 @@
-use easy_cast::{Error, traits::*};
+use easy_cast::{RangeError, traits::*};
 
 macro_rules! assert_signed_to_unsigned {
     ($src:ty => $dst:ty) => {
         assert_eq!(<$dst>::try_conv(0 as $src), Ok(0 as $dst));
         assert_eq!(<$dst>::try_conv(1 as $src), Ok(1 as $dst));
         assert_eq!(<$dst>::try_conv(<$src>::MAX), Ok(<$src>::MAX as $dst));
-        assert_eq!(<$dst>::try_conv(-1 as $src), Err(Error::Range));
+        assert_eq!(<$dst>::try_conv(-1 as $src), Err(RangeError));
     };
     ($src:ty => $($dst:ty),+ $(,)?) => {
         $(assert_signed_to_unsigned!($src => $dst);)+
@@ -19,7 +19,7 @@ macro_rules! assert_unsigned_to_signed {
         assert_eq!(<$dst>::try_conv(<$dst>::MAX as $src), Ok(<$dst>::MAX));
         assert_eq!(
             <$dst>::try_conv((<$dst>::MAX as $src) + 1),
-            Err(Error::Range)
+            Err(RangeError)
         );
     };
     ($src:ty => $($dst:ty),+ $(,)?) => {
@@ -62,8 +62,8 @@ fn unsigned_to_signed_boundaries() {
 fn narrowing_signed_to_signed_boundaries() {
     assert_eq!(i8::try_conv(i32::from(i8::MIN)), Ok(i8::MIN));
     assert_eq!(i8::try_conv(i32::from(i8::MAX)), Ok(i8::MAX));
-    assert_eq!(i8::try_conv(i32::from(i8::MIN) - 1), Err(Error::Range));
-    assert_eq!(i8::try_conv(i32::from(i8::MAX) + 1), Err(Error::Range));
+    assert_eq!(i8::try_conv(i32::from(i8::MIN) - 1), Err(RangeError));
+    assert_eq!(i8::try_conv(i32::from(i8::MAX) + 1), Err(RangeError));
 }
 
 #[test]
@@ -71,8 +71,8 @@ fn isize_usize_boundaries() {
     assert_eq!(isize::try_conv(isize::MAX), Ok(isize::MAX));
     assert_eq!(usize::try_conv(0isize), Ok(0usize));
     assert_eq!(usize::try_conv(1isize), Ok(1usize));
-    assert_eq!(usize::try_conv(-1isize), Err(Error::Range));
-    assert_eq!(isize::try_conv(usize::MAX), Err(Error::Range));
+    assert_eq!(usize::try_conv(-1isize), Err(RangeError));
+    assert_eq!(isize::try_conv(usize::MAX), Err(RangeError));
 }
 
 #[test]

--- a/tests/tuple_conv.rs
+++ b/tests/tuple_conv.rs
@@ -1,7 +1,7 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
 use easy_cast::generic::{Ceil, Floor, Nearest, Trunc};
-use easy_cast::{Error, traits::*};
+use easy_cast::{Error, RangeError, traits::*};
 
 #[test]
 fn tuple_arities() {
@@ -33,7 +33,7 @@ fn tuple_conversions_cover_mixed_types_and_errors() {
         Ok((42u8, -12i16, 1.25f64)),
     );
 
-    assert_eq!(<(u8,)>::try_conv((256u16,)), Err(Error::Range));
+    assert_eq!(<(u8,)>::try_conv((256u16,)), Err(RangeError));
     assert_eq!(<(u8, i8)>::try_conv((1u16, 128i16)), Err(Error::Range));
     assert_eq!(
         <(u8, i8, u16)>::try_conv((1u16, -1i16, 70_000u32)),


### PR DESCRIPTION
Motivation: we can without significant impact. This may improve code gen in some cases where conversions are known to be infallible.