### PR TITLE
Renames: RoundTo → CastTo, RoundFrom → ConvTo; Nearest int-to-float rounding

### DIFF
--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,7 +10,7 @@
 //! traits support generality over [`Rounding`] modes and more precise error
 //! types as associated types.
 //!
-//! [`RoundInto`] and [`RoundFrom`] may be used instead of
+//! [`CastTo`] and [`RoundFrom`] may be used instead of
 //! [`Cast`](crate::Cast) and [`Conv`](crate::Conv) where genericity over
 //! [`Rounding`] modes is required.
 //!
@@ -23,7 +23,7 @@
 //! modes, for example an [`Approx`] conversion (which rounds inputs where
 //! required) and an [`Exact`] conversion (which rejects these inputs).
 //!
-//! [`RoundInto`]: crate::RoundInto
+//! [`CastTo`]: crate::CastTo
 //! [`RoundFrom`]: crate::RoundFrom
 
 use crate::RangeError;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -10,7 +10,7 @@
 //! traits support generality over [`Rounding`] modes and more precise error
 //! types as associated types.
 //!
-//! [`CastTo`] and [`RoundFrom`] may be used instead of
+//! [`CastTo`] and [`ConvTo`] may be used instead of
 //! [`Cast`](crate::Cast) and [`Conv`](crate::Conv) where genericity over
 //! [`Rounding`] modes is required.
 //!
@@ -24,7 +24,7 @@
 //! required) and an [`Exact`] conversion (which rejects these inputs).
 //!
 //! [`CastTo`]: crate::CastTo
-//! [`RoundFrom`]: crate::RoundFrom
+//! [`ConvTo`]: crate::ConvTo
 
 use crate::RangeError;
 

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -8,7 +8,7 @@
 //! See also `impl_basic` which inherits integer impls from From.
 
 use crate::generic::{Approx, Convert, ConvertExact, Exact};
-use crate::{Error, RangeError, RoundInto};
+use crate::{CastTo, Error, RangeError};
 use core::convert::Infallible;
 use core::mem::size_of;
 
@@ -246,7 +246,7 @@ macro_rules! impl_via_digits_check {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    x.try_round(Exact).unwrap_or_else(|_| {
+                    x.try_cast_to(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -283,7 +283,7 @@ macro_rules! impl_via_digits_check_signed {
             #[inline]
             fn convert(x: $x) -> Self {
                 if cfg!(any(debug_assertions, feature = "assert_digits")) {
-                    x.try_round(Exact).unwrap_or_else(|_| {
+                    x.try_cast_to(Exact).unwrap_or_else(|_| {
                         panic!(
                             "cast x: {} to {}: inexact for x = {x}",
                             stringify!($x), stringify!($y)
@@ -330,7 +330,7 @@ impl Convert<u128, Exact> for f32 {
     #[inline]
     fn convert(x: u128) -> Self {
         if cfg!(any(debug_assertions, feature = "assert_digits")) {
-            x.try_round(Exact)
+            x.try_cast_to(Exact)
                 .unwrap_or_else(|_| panic!("cast x: u128 to f32: inexact for x = {x}"))
         } else {
             x as f32

--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -365,6 +365,21 @@ macro_rules! impl_approx {
                 Ok(x as $y)
             }
         }
+
+        // Note: `as` numeric int-to-float casts round to nearest
+        #[cfg(any(feature = "std", feature = "libm"))]
+        impl Convert<$x, crate::generic::Nearest> for $y {
+            type Error = Infallible;
+
+            #[inline]
+            fn convert(x: $x) -> Self {
+                x as $y
+            }
+            #[inline]
+            fn try_convert(x: $x) -> Result<Self, Infallible> {
+                Ok(x as $y)
+            }
+        }
     };
     ($x:ty: $y:tt, $($yy:tt),+) => {
         impl_approx!($x: $y);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!     conversions
 //! -   Use [`CastApprox`] and [`ConvApprox`] for approximate conversions
 //!     (rounding mode is implementation-defined just like `as`)
-//! -   Use [`RoundFrom`] and [`RoundInto`] with an explicit rounding mode
+//! -   Use [`RoundFrom`] and [`CastTo`] with an explicit rounding mode
 //!     ([`generic::Trunc`], [`generic::Nearest`], [`generic::Floor`],
 //!     [`generic::Ceil`]) for conversions with a specified rounding mode
 //!     (requires `std` or `libm` feature)
@@ -75,7 +75,7 @@
 //! [`traits`] when supporting additional types.
 //!
 //! It is recommended to use the [`traits`] traits to convert values. In
-//! implementations of generic traits, [`RoundFrom`] and [`RoundInto`] are
+//! implementations of generic traits, [`RoundFrom`] and [`CastTo`] are
 //! usually the most appropriate traits to use.
 //!
 //! [`TryFrom`]: core::convert::TryFrom

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!     conversions
 //! -   Use [`CastApprox`] and [`ConvApprox`] for approximate conversions
 //!     (rounding mode is implementation-defined just like `as`)
-//! -   Use [`RoundFrom`] and [`CastTo`] with an explicit rounding mode
+//! -   Use [`ConvTo`] and [`CastTo`] with an explicit rounding mode
 //!     ([`generic::Trunc`], [`generic::Nearest`], [`generic::Floor`],
 //!     [`generic::Ceil`]) for conversions with a specified rounding mode
 //!     (requires `std` or `libm` feature)
@@ -43,7 +43,7 @@
 //! ```
 //! use easy_cast::traits::*;
 //! use easy_cast::generic::Nearest;
-//! use easy_cast::RoundFrom;
+//! use easy_cast::ConvTo;
 //!
 //! fn nth_root<X: CastApprox<f64>>(x: X, n: u32) {
 //!     let x = x.cast_approx();    // Into-like approximate conversion
@@ -58,7 +58,7 @@
 //!     println!("The {n}-th root of {x} is {root}");
 //!
 //!     // TryFrom-like approximate (nearest) conversion
-//!     if let Ok(nearest) = isize::try_round_from(root, Nearest) {
+//!     if let Ok(nearest) = isize::try_conv_to(root, Nearest) {
 //!         println!("Nearest integer: {nearest}");
 //!     }
 //! }
@@ -75,7 +75,7 @@
 //! [`traits`] when supporting additional types.
 //!
 //! It is recommended to use the [`traits`] traits to convert values. In
-//! implementations of generic traits, [`RoundFrom`] and [`CastTo`] are
+//! implementations of generic traits, [`ConvTo`] and [`CastTo`] are
 //! usually the most appropriate traits to use.
 //!
 //! [`TryFrom`]: core::convert::TryFrom

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //!     println!("The {n}-th root of {x} is {root}");
 //!
 //!     // TryFrom-like approximate (nearest) conversion
-//!     if let Ok(nearest) = isize::try_conv_to(root, Nearest) {
+//!     if let Ok(nearest) = isize::try_conv_to(Nearest, root) {
 //!         println!("Nearest integer: {nearest}");
 //!     }
 //! }

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -58,11 +58,16 @@ impl Rounding for Trunc {
     type MaximumError = RangeError;
 }
 
-/// Round to nearest integer
+/// Round to the nearest representable value
 ///
-/// Half-way cases are rounded away from `0`.
+/// Half-way cases are rounded away from zero. This is the rounding mode used by
+/// [`as` numeric casts] for integer to floating-point conversions.
 ///
 /// Example: `2.5_f32` converts to `3_i32`, `-2.5_f32` converts to `-3_i32`.
+/// Another example: converting `i32::MAX` to `f32` rounds up (effectively to
+/// `1u32 << 31 = (i32::MAX as u32) + 1`).
+///
+/// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
 #[cfg(any(feature = "std", feature = "libm"))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Nearest;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -7,10 +7,10 @@
 //!
 //! This module only contains traits, allowing relatively safe glob-import:
 //! ```
-//! use easy_cast::{Cast, RoundFrom, generic::Nearest};
+//! use easy_cast::{Cast, ConvTo, generic::Nearest};
 //!
 //! # fn main() {
-//! let x = i32::round_from(8.5f32, Nearest);
+//! let x = i32::conv_to(8.5f32, Nearest);
 //! let y: f32 = 12.cast();
 //! # }
 //! ```
@@ -137,7 +137,7 @@ impl<S, T: Conv<S>> Cast<T> for S {
 /// Only one failure mode is allowed: domain ([`RangeError`]).
 ///
 /// The rounding mode is implementation-defined, usually aligning with the
-/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`CastTo`] with
+/// behavior of [`as` numeric casts]. Use [`ConvTo`] or [`CastTo`] with
 /// an explicit rounding mode (e.g. [`generic::Nearest`](crate::generic::Nearest))
 /// instead where control over rounding is required.
 ///
@@ -211,7 +211,7 @@ impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
 /// `f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0) = 1.0`.
 ///
 /// The rounding mode is implementation-defined, usually aligning with the
-/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`CastTo`] with
+/// behavior of [`as` numeric casts]. Use [`ConvTo`] or [`CastTo`] with
 /// an explicit rounding mode (e.g. [`generic::Nearest`](crate::generic::Nearest))
 /// instead where control over rounding is required.
 ///
@@ -253,23 +253,23 @@ impl<S, T: ConvApprox<S>> CastApprox<T> for S {
     }
 }
 
-/// Generic "from" conversion trait
+/// Generic "from" conversion trait with specified rounding mode
 ///
-/// This trait is like [`From`] but for [`Convert`].
+/// This trait is like [`From`] but for [`Convert`]. It is similar to
+/// [`Conv`] but provides control over the rounding mode used.
 ///
 /// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `x.try_round_from(Exact)` or `y.round_from(Approx)`. In generic
-/// code (where `R: Rounding`), `z.try_round_from(R::default())` may be used.
-pub trait RoundFrom<S, R: Rounding>: Sized {
+/// for example `f32::try_conv_to(Exact, x)` or `i32::conv_to(Approx, y)`.
+pub trait ConvTo<S, R: Rounding>: Sized {
     /// Conversion error type
     type Error: Into<R::MaximumError> + core::error::Error;
 
     /// Try converting from `S` to `Self`
-    fn try_round_from(s: S, mode: R) -> Result<Self, Self::Error>;
+    fn try_conv_to(s: S, mode: R) -> Result<Self, Self::Error>;
 
     /// Convert from `S` to `Self`
     ///
-    /// This method must return the same result as [`Self::try_round_from`] where
+    /// This method must return the same result as [`Self::try_conv_to`] where
     /// that method succeeds, but differs in the handling of errors:
     ///
     /// -   In debug builds the method must panic on error
@@ -278,24 +278,24 @@ pub trait RoundFrom<S, R: Rounding>: Sized {
     ///     optimize to [`as` numeric casts].
     ///
     /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
-    fn round_from(s: S, mode: R) -> Self;
+    fn conv_to(s: S, mode: R) -> Self;
 }
 
-impl<R: Rounding, S, T: Convert<S, R>> RoundFrom<S, R> for T {
+impl<R: Rounding, S, T: Convert<S, R>> ConvTo<S, R> for T {
     type Error = T::Error;
 
-    fn try_round_from(s: S, _: R) -> Result<Self, Self::Error> {
+    fn try_conv_to(s: S, _: R) -> Result<Self, Self::Error> {
         T::try_convert(s)
     }
 
-    fn round_from(s: S, _: R) -> Self {
+    fn conv_to(s: S, _: R) -> Self {
         T::convert(s)
     }
 }
 
 /// Generic "into" conversion trait with specified rounding mode
 ///
-/// This trait is like [`Into`] but for [`RoundFrom`]. It is similar to
+/// This trait is like [`Into`] but for [`ConvTo`]. It is similar to
 /// [`Cast`] but provides control over rounding modes.
 ///
 /// The [`Rounding`] mode must be specified when calling this trait's methods,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,7 @@
 //! use easy_cast::{Cast, ConvTo, generic::Nearest};
 //!
 //! # fn main() {
-//! let x = i32::conv_to(8.5f32, Nearest);
+//! let x = i32::conv_to(Nearest, 8.5f32);
 //! let y: f32 = 12.cast();
 //! # }
 //! ```
@@ -265,7 +265,7 @@ pub trait ConvTo<S, R: Rounding>: Sized {
     type Error: Into<R::MaximumError> + core::error::Error;
 
     /// Try converting from `S` to `Self`
-    fn try_conv_to(s: S, mode: R) -> Result<Self, Self::Error>;
+    fn try_conv_to(mode: R, s: S) -> Result<Self, Self::Error>;
 
     /// Convert from `S` to `Self`
     ///
@@ -278,17 +278,17 @@ pub trait ConvTo<S, R: Rounding>: Sized {
     ///     optimize to [`as` numeric casts].
     ///
     /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
-    fn conv_to(s: S, mode: R) -> Self;
+    fn conv_to(mode: R, s: S) -> Self;
 }
 
 impl<R: Rounding, S, T: Convert<S, R>> ConvTo<S, R> for T {
     type Error = T::Error;
 
-    fn try_conv_to(s: S, _: R) -> Result<Self, Self::Error> {
+    fn try_conv_to(_: R, s: S) -> Result<Self, Self::Error> {
         T::try_convert(s)
     }
 
-    fn conv_to(s: S, _: R) -> Self {
+    fn conv_to(_: R, s: S) -> Self {
         T::convert(s)
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,10 +33,8 @@ use crate::{Error, RangeError};
 ///     both `i32` and `u8`, attempting to convert `-1` to `u8` will fail with
 ///     [`RangeError`].
 ///
-/// The sister-trait [`Cast`] supports "into" style usage.
-///
-/// It is recommended not to implement this trait directly but to instead
-/// implement one of the [`generic`](crate::generic) traits.
+/// The sister-trait [`Cast`] supports "into" style usage. The more generic
+/// trait [`ConvTo`] allows control over the rounding mode.
 pub trait Conv<S>: Sized {
     /// Conversion error type
     type Error: Into<Error> + core::error::Error;
@@ -89,6 +87,8 @@ impl<S, T: Convert<S, Exact>> Conv<S> for T {
 ///
 /// This trait is automatically implemented for every implementation of
 /// [`Conv`].
+///
+/// The more generic trait [`CastTo`] allows control over the rounding mode.
 pub trait Cast<T> {
     /// Conversion error type
     type Error: Into<Error> + core::error::Error;
@@ -255,11 +255,16 @@ impl<S, T: ConvApprox<S>> CastApprox<T> for S {
 
 /// Generic "from" conversion trait with specified rounding mode
 ///
-/// This trait is like [`From`] but for [`Convert`]. It is similar to
-/// [`Conv`] but provides control over the rounding mode used.
+/// This trait is similar to [`TryFrom`] but for numeric conversions with a
+/// specified rounding mode. Usage with rounding mode [`Exact`] is equivalent to
+/// [`Conv`].
 ///
-/// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `f32::try_conv_to(Exact, x)` or `i32::conv_to(Approx, y)`.
+/// The [`Rounding`] mode must be specified:
+/// ```
+/// # use easy_cast::{generic::{Exact, Nearest}, ConvTo};
+/// assert_eq!(i32::conv_to(Nearest, 7.6f32), 8);
+/// assert_eq!(f32::conv_to(Exact, 20), 20.0);
+/// ```
 pub trait ConvTo<S, R: Rounding>: Sized {
     /// Conversion error type
     type Error: Into<R::MaximumError> + core::error::Error;
@@ -295,12 +300,20 @@ impl<R: Rounding, S, T: Convert<S, R>> ConvTo<S, R> for T {
 
 /// Generic "into" conversion trait with specified rounding mode
 ///
-/// This trait is like [`Into`] but for [`ConvTo`]. It is similar to
-/// [`Cast`] but provides control over rounding modes.
+/// This trait is like [`TryInto`] but for for numeric conversions with a
+/// specified rounding mode. Usage with rounding mode [`Exact`] is equivalent to
+/// [`Cast`].
 ///
-/// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `x.try_cast_to(Exact)` or `y.cast_to(Approx)`. In generic code
-/// (where `R: Rounding`), `z.try_cast_to(R::default())` may be used.
+/// The [`Rounding`] mode must be specified:
+/// ```
+/// # use easy_cast::{generic::{Floor, Nearest}, CastTo};
+/// let x: i32 = 3.14192.cast_to(Floor);
+/// assert_eq!(x, 3);
+///
+/// let y = (1i32 << 30) - 1;
+/// let z: f32 = y.cast_to(Nearest);  // this example rounds up
+/// assert_eq!(z as i32, 1i32 << 30);
+/// ```
 pub trait CastTo<T, R: Rounding>: Sized {
     /// Conversion error type
     type Error: Into<R::MaximumError> + core::error::Error;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -137,7 +137,7 @@ impl<S, T: Conv<S>> Cast<T> for S {
 /// Only one failure mode is allowed: domain ([`RangeError`]).
 ///
 /// The rounding mode is implementation-defined, usually aligning with the
-/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`RoundInto`] with
+/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`CastTo`] with
 /// an explicit rounding mode (e.g. [`generic::Nearest`](crate::generic::Nearest))
 /// instead where control over rounding is required.
 ///
@@ -211,7 +211,7 @@ impl<S, T: Convert<S, Approx>> ConvApprox<S> for T {
 /// `f32::conv_approx(1f64 + (f32::EPSILON as f64) / 2.0) = 1.0`.
 ///
 /// The rounding mode is implementation-defined, usually aligning with the
-/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`RoundInto`] with
+/// behavior of [`as` numeric casts]. Use [`RoundFrom`] or [`CastTo`] with
 /// an explicit rounding mode (e.g. [`generic::Nearest`](crate::generic::Nearest))
 /// instead where control over rounding is required.
 ///
@@ -293,23 +293,24 @@ impl<R: Rounding, S, T: Convert<S, R>> RoundFrom<S, R> for T {
     }
 }
 
-/// Generic "into" conversion trait
+/// Generic "into" conversion trait with specified rounding mode
 ///
-/// This trait is like [`Into`] but for [`Convert`].
+/// This trait is like [`Into`] but for [`RoundFrom`]. It is similar to
+/// [`Cast`] but provides control over rounding modes.
 ///
 /// The [`Rounding`] mode must be specified when calling this trait's methods,
-/// for example `x.try_round(Exact)` or `y.round(Approx)`. In generic code
-/// (where `R: Rounding`), `z.try_round(R::default())` may be used.
-pub trait RoundInto<T, R: Rounding>: Sized {
+/// for example `x.try_cast_to(Exact)` or `y.cast_to(Approx)`. In generic code
+/// (where `R: Rounding`), `z.try_cast_to(R::default())` may be used.
+pub trait CastTo<T, R: Rounding>: Sized {
     /// Conversion error type
     type Error: Into<R::MaximumError> + core::error::Error;
 
     /// Try converting from `Self` to `T`
-    fn try_round(self, mode: R) -> Result<T, Self::Error>;
+    fn try_cast_to(self, mode: R) -> Result<T, Self::Error>;
 
     /// Convert from `Self` to `T`
     ///
-    /// This method must return the same result as [`Self::try_round`] where
+    /// This method must return the same result as [`Self::try_cast_to`] where
     /// that method succeeds, but differs in the handling of errors:
     ///
     /// -   In debug builds the method must panic on error
@@ -318,17 +319,17 @@ pub trait RoundInto<T, R: Rounding>: Sized {
     ///     optimize to [`as` numeric casts].
     ///
     /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
-    fn round(self, mode: R) -> T;
+    fn cast_to(self, mode: R) -> T;
 }
 
-impl<R: Rounding, S, T: Convert<S, R>> RoundInto<T, R> for S {
+impl<R: Rounding, S, T: Convert<S, R>> CastTo<T, R> for S {
     type Error = T::Error;
 
-    fn try_round(self, _: R) -> Result<T, Self::Error> {
+    fn try_cast_to(self, _: R) -> Result<T, Self::Error> {
         T::try_convert(self)
     }
 
-    fn round(self, _: R) -> T {
+    fn cast_to(self, _: R) -> T {
         T::convert(self)
     }
 }

--- a/tests/array_conv.rs
+++ b/tests/array_conv.rs
@@ -19,23 +19,23 @@ fn zero_length_array_conversions_work() {
 #[test]
 fn float_array_conversions_cover_all_rounding_modes() {
     assert_eq!(
-        <[i32; 3]>::try_conv_to([1.9f32, -1.9, 2.0], Trunc),
+        <[i32; 3]>::try_conv_to(Trunc, [1.9f32, -1.9, 2.0]),
         Ok([1i32, -1, 2])
     );
     assert_eq!(
-        <[i32; 3]>::try_conv_to([1.5f32, -1.5, 2.4], Nearest),
+        <[i32; 3]>::try_conv_to(Nearest, [1.5f32, -1.5, 2.4]),
         Ok([2i32, -2, 2]),
     );
     assert_eq!(
-        <[i32; 3]>::try_conv_to([1.9f32, -1.1, 2.0], Floor),
+        <[i32; 3]>::try_conv_to(Floor, [1.9f32, -1.1, 2.0]),
         Ok([1i32, -2, 2])
     );
     assert_eq!(
-        <[i32; 3]>::try_conv_to([1.1f32, -1.9, 2.0], Ceil),
+        <[i32; 3]>::try_conv_to(Ceil, [1.1f32, -1.9, 2.0]),
         Ok([2i32, -1, 2])
     );
     assert_eq!(
-        <[u8; 3]>::try_conv_to([1.0f32, 256.0, 3.0], Trunc),
+        <[u8; 3]>::try_conv_to(Trunc, [1.0f32, 256.0, 3.0]),
         Err(RangeError)
     );
 }

--- a/tests/array_conv.rs
+++ b/tests/array_conv.rs
@@ -2,7 +2,7 @@
 
 use easy_cast::generic::{Ceil, Floor, Nearest, Trunc};
 use easy_cast::traits::*;
-use easy_cast::{RangeError, RoundFrom};
+use easy_cast::{ConvTo, RangeError};
 
 #[test]
 fn integer_array_conversions_cover_success_and_failure() {
@@ -19,23 +19,23 @@ fn zero_length_array_conversions_work() {
 #[test]
 fn float_array_conversions_cover_all_rounding_modes() {
     assert_eq!(
-        <[i32; 3]>::try_round_from([1.9f32, -1.9, 2.0], Trunc),
+        <[i32; 3]>::try_conv_to([1.9f32, -1.9, 2.0], Trunc),
         Ok([1i32, -1, 2])
     );
     assert_eq!(
-        <[i32; 3]>::try_round_from([1.5f32, -1.5, 2.4], Nearest),
+        <[i32; 3]>::try_conv_to([1.5f32, -1.5, 2.4], Nearest),
         Ok([2i32, -2, 2]),
     );
     assert_eq!(
-        <[i32; 3]>::try_round_from([1.9f32, -1.1, 2.0], Floor),
+        <[i32; 3]>::try_conv_to([1.9f32, -1.1, 2.0], Floor),
         Ok([1i32, -2, 2])
     );
     assert_eq!(
-        <[i32; 3]>::try_round_from([1.1f32, -1.9, 2.0], Ceil),
+        <[i32; 3]>::try_conv_to([1.1f32, -1.9, 2.0], Ceil),
         Ok([2i32, -1, 2])
     );
     assert_eq!(
-        <[u8; 3]>::try_round_from([1.0f32, 256.0, 3.0], Trunc),
+        <[u8; 3]>::try_conv_to([1.0f32, 256.0, 3.0], Trunc),
         Err(RangeError)
     );
 }

--- a/tests/float_to_int.rs
+++ b/tests/float_to_int.rs
@@ -5,34 +5,34 @@ use easy_cast::{ConvTo, RangeError};
 
 #[test]
 fn float_boundaries_for_small_integer_types() {
-    assert_eq!(i8::try_conv_to(f32::from(i8::MIN), Trunc), Ok(i8::MIN));
-    assert_eq!(i8::try_conv_to(f32::from(i8::MAX), Trunc), Ok(i8::MAX));
+    assert_eq!(i8::try_conv_to(Trunc, f32::from(i8::MIN)), Ok(i8::MIN));
+    assert_eq!(i8::try_conv_to(Trunc, f32::from(i8::MAX)), Ok(i8::MAX));
     assert_eq!(
-        i8::try_conv_to(f32::from(i8::MIN) - 1.0, Trunc),
+        i8::try_conv_to(Trunc, f32::from(i8::MIN) - 1.0),
         Err(RangeError)
     );
     assert_eq!(
-        i8::try_conv_to(f32::from(i8::MAX) + 1.0, Trunc),
-        Err(RangeError)
-    );
-
-    assert_eq!(u8::try_conv_to(255.0f32, Nearest), Ok(u8::MAX));
-    assert_eq!(u8::try_conv_to(256.0f32, Nearest), Err(RangeError));
-
-    assert_eq!(i16::try_conv_to(f64::from(i16::MIN), Floor), Ok(i16::MIN));
-    assert_eq!(i16::try_conv_to(f64::from(i16::MAX), Ceil), Ok(i16::MAX));
-    assert_eq!(
-        i16::try_conv_to(f64::from(i16::MIN) - 1.0, Floor),
-        Err(RangeError)
-    );
-    assert_eq!(
-        i16::try_conv_to(f64::from(i16::MAX) + 1.0, Ceil),
+        i8::try_conv_to(Trunc, f32::from(i8::MAX) + 1.0),
         Err(RangeError)
     );
 
-    assert_eq!(u32::try_conv_to(f64::from(u32::MAX), Trunc), Ok(u32::MAX));
+    assert_eq!(u8::try_conv_to(Nearest, 255.0f32), Ok(u8::MAX));
+    assert_eq!(u8::try_conv_to(Nearest, 256.0f32), Err(RangeError));
+
+    assert_eq!(i16::try_conv_to(Floor, f64::from(i16::MIN)), Ok(i16::MIN));
+    assert_eq!(i16::try_conv_to(Ceil, f64::from(i16::MAX)), Ok(i16::MAX));
     assert_eq!(
-        u32::try_conv_to(f64::from(u32::MAX) + 1.0, Trunc),
+        i16::try_conv_to(Floor, f64::from(i16::MIN) - 1.0),
+        Err(RangeError)
+    );
+    assert_eq!(
+        i16::try_conv_to(Ceil, f64::from(i16::MAX) + 1.0),
+        Err(RangeError)
+    );
+
+    assert_eq!(u32::try_conv_to(Trunc, f64::from(u32::MAX)), Ok(u32::MAX));
+    assert_eq!(
+        u32::try_conv_to(Trunc, f64::from(u32::MAX) + 1.0),
         Err(RangeError)
     );
 }
@@ -40,45 +40,45 @@ fn float_boundaries_for_small_integer_types() {
 #[test]
 fn nan_and_infinity_are_range_errors_for_all_modes() {
     for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
-        assert_eq!(i8::try_conv_to(value, Trunc), Err(RangeError));
-        assert_eq!(i8::try_conv_to(value, Nearest), Err(RangeError));
-        assert_eq!(i8::try_conv_to(value, Floor), Err(RangeError));
-        assert_eq!(i8::try_conv_to(value, Ceil), Err(RangeError));
+        assert_eq!(i8::try_conv_to(Trunc, value), Err(RangeError));
+        assert_eq!(i8::try_conv_to(Nearest, value), Err(RangeError));
+        assert_eq!(i8::try_conv_to(Floor, value), Err(RangeError));
+        assert_eq!(i8::try_conv_to(Ceil, value), Err(RangeError));
 
-        assert_eq!(u128::try_conv_to(value, Trunc), Err(RangeError));
-        assert_eq!(u128::try_conv_to(value, Nearest), Err(RangeError));
-        assert_eq!(u128::try_conv_to(value, Floor), Err(RangeError));
-        assert_eq!(u128::try_conv_to(value, Ceil), Err(RangeError));
+        assert_eq!(u128::try_conv_to(Trunc, value), Err(RangeError));
+        assert_eq!(u128::try_conv_to(Nearest, value), Err(RangeError));
+        assert_eq!(u128::try_conv_to(Floor, value), Err(RangeError));
+        assert_eq!(u128::try_conv_to(Ceil, value), Err(RangeError));
     }
 
     for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-        assert_eq!(i16::try_conv_to(value, Trunc), Err(RangeError));
-        assert_eq!(i16::try_conv_to(value, Nearest), Err(RangeError));
-        assert_eq!(i16::try_conv_to(value, Floor), Err(RangeError));
-        assert_eq!(i16::try_conv_to(value, Ceil), Err(RangeError));
+        assert_eq!(i16::try_conv_to(Trunc, value), Err(RangeError));
+        assert_eq!(i16::try_conv_to(Nearest, value), Err(RangeError));
+        assert_eq!(i16::try_conv_to(Floor, value), Err(RangeError));
+        assert_eq!(i16::try_conv_to(Ceil, value), Err(RangeError));
     }
 }
 
 #[test]
 fn f32_to_u128_special_case() {
     let max = 0xFFFFFF00_00000000_00000000_00000000u128;
-    assert_eq!(u128::try_conv_to(f32::MAX, Trunc), Ok(max));
-    assert_eq!(u128::try_conv_to(f32::MAX, Nearest), Ok(max));
-    assert_eq!(u128::try_conv_to(f32::MAX, Floor), Ok(max));
-    assert_eq!(u128::try_conv_to(f32::MAX, Ceil), Ok(max));
-    assert_eq!(u128::try_conv_to(0.0f32, Trunc), Ok(0u128));
-    assert_eq!(u128::try_conv_to(-1.0f32, Trunc), Err(RangeError));
-    assert_eq!(u128::try_conv_to(f32::INFINITY, Trunc), Err(RangeError));
+    assert_eq!(u128::try_conv_to(Trunc, f32::MAX), Ok(max));
+    assert_eq!(u128::try_conv_to(Nearest, f32::MAX), Ok(max));
+    assert_eq!(u128::try_conv_to(Floor, f32::MAX), Ok(max));
+    assert_eq!(u128::try_conv_to(Ceil, f32::MAX), Ok(max));
+    assert_eq!(u128::try_conv_to(Trunc, 0.0f32), Ok(0u128));
+    assert_eq!(u128::try_conv_to(Trunc, -1.0f32), Err(RangeError));
+    assert_eq!(u128::try_conv_to(Trunc, f32::INFINITY), Err(RangeError));
 }
 
 #[test]
 #[should_panic(expected = "cast x: f32 to i16 (trunc): range error for x = 32768")]
 fn float_round_trunc_panics_with_expected_message() {
-    i16::conv_to(32768.0f32, Trunc);
+    i16::conv_to(Trunc, 32768.0f32);
 }
 
 #[test]
 #[should_panic(expected = "cast x: f64 to u8 (ceil): range error for x = -1.1")]
 fn float_round_ceil_panics_with_expected_message() {
-    u8::conv_to(-1.1f64, Ceil);
+    u8::conv_to(Ceil, -1.1f64);
 }

--- a/tests/float_to_int.rs
+++ b/tests/float_to_int.rs
@@ -1,44 +1,38 @@
 #![cfg(any(feature = "std", feature = "libm"))]
 
 use easy_cast::generic::{Ceil, Floor, Nearest, Trunc};
-use easy_cast::{RangeError, RoundFrom};
+use easy_cast::{ConvTo, RangeError};
 
 #[test]
 fn float_boundaries_for_small_integer_types() {
-    assert_eq!(i8::try_round_from(f32::from(i8::MIN), Trunc), Ok(i8::MIN));
-    assert_eq!(i8::try_round_from(f32::from(i8::MAX), Trunc), Ok(i8::MAX));
+    assert_eq!(i8::try_conv_to(f32::from(i8::MIN), Trunc), Ok(i8::MIN));
+    assert_eq!(i8::try_conv_to(f32::from(i8::MAX), Trunc), Ok(i8::MAX));
     assert_eq!(
-        i8::try_round_from(f32::from(i8::MIN) - 1.0, Trunc),
+        i8::try_conv_to(f32::from(i8::MIN) - 1.0, Trunc),
         Err(RangeError)
     );
     assert_eq!(
-        i8::try_round_from(f32::from(i8::MAX) + 1.0, Trunc),
-        Err(RangeError)
-    );
-
-    assert_eq!(u8::try_round_from(255.0f32, Nearest), Ok(u8::MAX));
-    assert_eq!(u8::try_round_from(256.0f32, Nearest), Err(RangeError));
-
-    assert_eq!(
-        i16::try_round_from(f64::from(i16::MIN), Floor),
-        Ok(i16::MIN)
-    );
-    assert_eq!(i16::try_round_from(f64::from(i16::MAX), Ceil), Ok(i16::MAX));
-    assert_eq!(
-        i16::try_round_from(f64::from(i16::MIN) - 1.0, Floor),
-        Err(RangeError)
-    );
-    assert_eq!(
-        i16::try_round_from(f64::from(i16::MAX) + 1.0, Ceil),
+        i8::try_conv_to(f32::from(i8::MAX) + 1.0, Trunc),
         Err(RangeError)
     );
 
+    assert_eq!(u8::try_conv_to(255.0f32, Nearest), Ok(u8::MAX));
+    assert_eq!(u8::try_conv_to(256.0f32, Nearest), Err(RangeError));
+
+    assert_eq!(i16::try_conv_to(f64::from(i16::MIN), Floor), Ok(i16::MIN));
+    assert_eq!(i16::try_conv_to(f64::from(i16::MAX), Ceil), Ok(i16::MAX));
     assert_eq!(
-        u32::try_round_from(f64::from(u32::MAX), Trunc),
-        Ok(u32::MAX)
+        i16::try_conv_to(f64::from(i16::MIN) - 1.0, Floor),
+        Err(RangeError)
     );
     assert_eq!(
-        u32::try_round_from(f64::from(u32::MAX) + 1.0, Trunc),
+        i16::try_conv_to(f64::from(i16::MAX) + 1.0, Ceil),
+        Err(RangeError)
+    );
+
+    assert_eq!(u32::try_conv_to(f64::from(u32::MAX), Trunc), Ok(u32::MAX));
+    assert_eq!(
+        u32::try_conv_to(f64::from(u32::MAX) + 1.0, Trunc),
         Err(RangeError)
     );
 }
@@ -46,45 +40,45 @@ fn float_boundaries_for_small_integer_types() {
 #[test]
 fn nan_and_infinity_are_range_errors_for_all_modes() {
     for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
-        assert_eq!(i8::try_round_from(value, Trunc), Err(RangeError));
-        assert_eq!(i8::try_round_from(value, Nearest), Err(RangeError));
-        assert_eq!(i8::try_round_from(value, Floor), Err(RangeError));
-        assert_eq!(i8::try_round_from(value, Ceil), Err(RangeError));
+        assert_eq!(i8::try_conv_to(value, Trunc), Err(RangeError));
+        assert_eq!(i8::try_conv_to(value, Nearest), Err(RangeError));
+        assert_eq!(i8::try_conv_to(value, Floor), Err(RangeError));
+        assert_eq!(i8::try_conv_to(value, Ceil), Err(RangeError));
 
-        assert_eq!(u128::try_round_from(value, Trunc), Err(RangeError));
-        assert_eq!(u128::try_round_from(value, Nearest), Err(RangeError));
-        assert_eq!(u128::try_round_from(value, Floor), Err(RangeError));
-        assert_eq!(u128::try_round_from(value, Ceil), Err(RangeError));
+        assert_eq!(u128::try_conv_to(value, Trunc), Err(RangeError));
+        assert_eq!(u128::try_conv_to(value, Nearest), Err(RangeError));
+        assert_eq!(u128::try_conv_to(value, Floor), Err(RangeError));
+        assert_eq!(u128::try_conv_to(value, Ceil), Err(RangeError));
     }
 
     for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-        assert_eq!(i16::try_round_from(value, Trunc), Err(RangeError));
-        assert_eq!(i16::try_round_from(value, Nearest), Err(RangeError));
-        assert_eq!(i16::try_round_from(value, Floor), Err(RangeError));
-        assert_eq!(i16::try_round_from(value, Ceil), Err(RangeError));
+        assert_eq!(i16::try_conv_to(value, Trunc), Err(RangeError));
+        assert_eq!(i16::try_conv_to(value, Nearest), Err(RangeError));
+        assert_eq!(i16::try_conv_to(value, Floor), Err(RangeError));
+        assert_eq!(i16::try_conv_to(value, Ceil), Err(RangeError));
     }
 }
 
 #[test]
 fn f32_to_u128_special_case() {
     let max = 0xFFFFFF00_00000000_00000000_00000000u128;
-    assert_eq!(u128::try_round_from(f32::MAX, Trunc), Ok(max));
-    assert_eq!(u128::try_round_from(f32::MAX, Nearest), Ok(max));
-    assert_eq!(u128::try_round_from(f32::MAX, Floor), Ok(max));
-    assert_eq!(u128::try_round_from(f32::MAX, Ceil), Ok(max));
-    assert_eq!(u128::try_round_from(0.0f32, Trunc), Ok(0u128));
-    assert_eq!(u128::try_round_from(-1.0f32, Trunc), Err(RangeError));
-    assert_eq!(u128::try_round_from(f32::INFINITY, Trunc), Err(RangeError));
+    assert_eq!(u128::try_conv_to(f32::MAX, Trunc), Ok(max));
+    assert_eq!(u128::try_conv_to(f32::MAX, Nearest), Ok(max));
+    assert_eq!(u128::try_conv_to(f32::MAX, Floor), Ok(max));
+    assert_eq!(u128::try_conv_to(f32::MAX, Ceil), Ok(max));
+    assert_eq!(u128::try_conv_to(0.0f32, Trunc), Ok(0u128));
+    assert_eq!(u128::try_conv_to(-1.0f32, Trunc), Err(RangeError));
+    assert_eq!(u128::try_conv_to(f32::INFINITY, Trunc), Err(RangeError));
 }
 
 #[test]
 #[should_panic(expected = "cast x: f32 to i16 (trunc): range error for x = 32768")]
 fn float_round_trunc_panics_with_expected_message() {
-    i16::round_from(32768.0f32, Trunc);
+    i16::conv_to(32768.0f32, Trunc);
 }
 
 #[test]
 #[should_panic(expected = "cast x: f64 to u8 (ceil): range error for x = -1.1")]
 fn float_round_ceil_panics_with_expected_message() {
-    u8::round_from(-1.1f64, Ceil);
+    u8::conv_to(-1.1f64, Ceil);
 }

--- a/tests/int_to_float.rs
+++ b/tests/int_to_float.rs
@@ -70,6 +70,21 @@ fn int_to_float_approx() {
     );
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
+#[test]
+fn int_to_float_nearest() {
+    use easy_cast::generic::Nearest;
+
+    // Repeat a few of the above tests using Nearest rounding (equivalent)
+    assert_eq!(f32::try_conv_to(Nearest, 0xFFFF_FF00u32), Ok(4294967040.0));
+    assert_eq!(f32::try_conv_to(Nearest, 0xFFFF_FF70u32), Ok(4294967040.0));
+    assert_eq!(f32::try_conv_to(Nearest, 0xFFFF_FF80u32), Ok(4294967168.0));
+    assert_eq!(
+        f32::try_conv_to(Nearest, 0xFFFF_FFFF_FFFF_FC00u64),
+        Ok(18446744073709550592.0)
+    );
+}
+
 #[test]
 fn int_to_float_overflow() {
     assert_eq!(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,10 +54,10 @@ fn int_to_float_inexact() {
 #[test]
 fn f32_max_to_u128() {
     let v = 0xFFFFFF00_00000000_00000000_00000000u128;
-    assert_eq!(u128::round_from(f32::MAX, Trunc), v);
-    assert_eq!(u128::round_from(f32::MAX, Nearest), v);
-    assert_eq!(u128::round_from(f32::MAX, Floor), v);
-    assert_eq!(u128::round_from(f32::MAX, Ceil), v);
+    assert_eq!(u128::conv_to(f32::MAX, Trunc), v);
+    assert_eq!(u128::conv_to(f32::MAX, Nearest), v);
+    assert_eq!(u128::conv_to(f32::MAX, Floor), v);
+    assert_eq!(u128::conv_to(f32::MAX, Ceil), v);
     assert_eq!(u128::conv_approx(f32::MAX), v);
 }
 
@@ -77,12 +77,12 @@ fn approx_float_to_int() {
 #[test]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_casts() {
-    assert_eq!(u64::round_from(13.2f32, Nearest), 13);
-    let x: i128 = i128::round_from(13.5f32, Nearest);
+    assert_eq!(u64::conv_to(13.2f32, Nearest), 13);
+    let x: i128 = i128::conv_to(13.5f32, Nearest);
     assert_eq!(x, 14);
-    assert_eq!(u8::round_from(13.8f64, Floor), 13);
-    assert_eq!(u32::round_from(13.1f32, Ceil), 14);
-    assert_eq!(i64::round_from(-3168565.13f64, Floor), -3168566);
+    assert_eq!(u8::conv_to(13.8f64, Floor), 13);
+    assert_eq!(u32::conv_to(13.1f32, Ceil), 14);
+    assert_eq!(i64::conv_to(-3168565.13f64, Floor), -3168566);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn float_trunc() {
     let xx = [-32768.0f32, -32768.99, -0.99, 0.99, 32767.99];
     let yy = [-32768i16, -32768, 0, 0, 32767];
     for (x, y) in xx[..].iter().zip(yy[..].iter()) {
-        assert_eq!(i16::round_from(*x, Trunc), *y);
+        assert_eq!(i16::conv_to(*x, Trunc), *y);
     }
 }
 
@@ -99,7 +99,7 @@ fn float_trunc() {
 #[should_panic(expected = "cast x: f32 to i16 (trunc): range error for x = 32768")]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_trunc_fail1() {
-    i16::round_from(32768.0f32, Trunc);
+    i16::conv_to(32768.0f32, Trunc);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,10 +54,10 @@ fn int_to_float_inexact() {
 #[test]
 fn f32_max_to_u128() {
     let v = 0xFFFFFF00_00000000_00000000_00000000u128;
-    assert_eq!(u128::conv_to(f32::MAX, Trunc), v);
-    assert_eq!(u128::conv_to(f32::MAX, Nearest), v);
-    assert_eq!(u128::conv_to(f32::MAX, Floor), v);
-    assert_eq!(u128::conv_to(f32::MAX, Ceil), v);
+    assert_eq!(u128::conv_to(Trunc, f32::MAX), v);
+    assert_eq!(u128::conv_to(Nearest, f32::MAX), v);
+    assert_eq!(u128::conv_to(Floor, f32::MAX), v);
+    assert_eq!(u128::conv_to(Ceil, f32::MAX), v);
     assert_eq!(u128::conv_approx(f32::MAX), v);
 }
 
@@ -77,12 +77,12 @@ fn approx_float_to_int() {
 #[test]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_casts() {
-    assert_eq!(u64::conv_to(13.2f32, Nearest), 13);
-    let x: i128 = i128::conv_to(13.5f32, Nearest);
+    assert_eq!(u64::conv_to(Nearest, 13.2f32), 13);
+    let x: i128 = i128::conv_to(Nearest, 13.5f32);
     assert_eq!(x, 14);
-    assert_eq!(u8::conv_to(13.8f64, Floor), 13);
-    assert_eq!(u32::conv_to(13.1f32, Ceil), 14);
-    assert_eq!(i64::conv_to(-3168565.13f64, Floor), -3168566);
+    assert_eq!(u8::conv_to(Floor, 13.8f64), 13);
+    assert_eq!(u32::conv_to(Ceil, 13.1f32), 14);
+    assert_eq!(i64::conv_to(Floor, -3168565.13f64), -3168566);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn float_trunc() {
     let xx = [-32768.0f32, -32768.99, -0.99, 0.99, 32767.99];
     let yy = [-32768i16, -32768, 0, 0, 32767];
     for (x, y) in xx[..].iter().zip(yy[..].iter()) {
-        assert_eq!(i16::conv_to(*x, Trunc), *y);
+        assert_eq!(i16::conv_to(Trunc, *x), *y);
     }
 }
 
@@ -99,7 +99,7 @@ fn float_trunc() {
 #[should_panic(expected = "cast x: f32 to i16 (trunc): range error for x = 32768")]
 #[cfg(any(feature = "std", feature = "libm"))]
 fn float_trunc_fail1() {
-    i16::conv_to(32768.0f32, Trunc);
+    i16::conv_to(Trunc, 32768.0f32);
 }
 
 #[test]

--- a/tests/tuple_conv.rs
+++ b/tests/tuple_conv.rs
@@ -56,16 +56,16 @@ fn tuple_conversions_cover_mixed_types_and_errors() {
 #[test]
 fn tuple_float_conversions_cover_all_rounding_modes() {
     assert_eq!(
-        <(i32, u8)>::try_conv_to((1.9f32, 2.9f32), Trunc),
+        <(i32, u8)>::try_conv_to(Trunc, (1.9f32, 2.9f32)),
         Ok((1, 2))
     );
     assert_eq!(
-        <(i32, u8)>::try_conv_to((1.5f32, 2.5f32), Nearest),
+        <(i32, u8)>::try_conv_to(Nearest, (1.5f32, 2.5f32)),
         Ok((2, 3))
     );
     assert_eq!(
-        <(i32, u8)>::try_conv_to((1.9f32, 2.9f32), Floor),
+        <(i32, u8)>::try_conv_to(Floor, (1.9f32, 2.9f32)),
         Ok((1, 2))
     );
-    assert_eq!(<(i32, u8)>::try_conv_to((1.1f32, 2.1f32), Ceil), Ok((2, 3)));
+    assert_eq!(<(i32, u8)>::try_conv_to(Ceil, (1.1f32, 2.1f32)), Ok((2, 3)));
 }

--- a/tests/tuple_conv.rs
+++ b/tests/tuple_conv.rs
@@ -56,19 +56,16 @@ fn tuple_conversions_cover_mixed_types_and_errors() {
 #[test]
 fn tuple_float_conversions_cover_all_rounding_modes() {
     assert_eq!(
-        <(i32, u8)>::try_round_from((1.9f32, 2.9f32), Trunc),
+        <(i32, u8)>::try_conv_to((1.9f32, 2.9f32), Trunc),
         Ok((1, 2))
     );
     assert_eq!(
-        <(i32, u8)>::try_round_from((1.5f32, 2.5f32), Nearest),
+        <(i32, u8)>::try_conv_to((1.5f32, 2.5f32), Nearest),
         Ok((2, 3))
     );
     assert_eq!(
-        <(i32, u8)>::try_round_from((1.9f32, 2.9f32), Floor),
+        <(i32, u8)>::try_conv_to((1.9f32, 2.9f32), Floor),
         Ok((1, 2))
     );
-    assert_eq!(
-        <(i32, u8)>::try_round_from((1.1f32, 2.1f32), Ceil),
-        Ok((2, 3))
-    );
+    assert_eq!(<(i32, u8)>::try_conv_to((1.1f32, 2.1f32), Ceil), Ok((2, 3)));
 }


### PR DESCRIPTION
Naming of the traits `RountTo` and `RoundFrom` is slightly problematic:

- `RoundTo::round` isn't usable on floats without UFCS since `round` is an inherent method
- Unlike `cast` and `conv`, it isn't immediately clear that `round_to(Nearest, x)` is a type-conversion

With this in mind we now have:
```rust
let x: f32 = 123.cast_to(Nearest);
let y = i32::conv_to(Nearest, 2.3);
```

Speaking of which, `Nearest` is now supported as a rounding mode for int-to-float conversions. (`Approx` is equivalent, but sometimes it is preferable to use `Nearest`.)