### PR TITLE
Un-feature-gate Trunc and some ConvTo impls; enable doc_cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.96.0"
 [package.metadata.docs.rs]
 features = []
 # To build locally:
-# cargo +nightly doc --open
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open
 
 [features]
 default = ["std"]

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -5,9 +5,9 @@
 
 //! Floating-point impls
 
-use crate::{Approx, ConvExact, ConvTo, Error, Exact, RangeError};
+use crate::{Approx, ConvExact, ConvTo, Error, Exact, RangeError, Trunc};
 #[cfg(any(feature = "std", feature = "libm"))]
-use crate::{Ceil, Floor, Nearest, Trunc};
+use crate::{Ceil, Floor, Nearest};
 
 impl ConvExact<f32> for f64 {
     type Error = RangeError;
@@ -110,7 +110,6 @@ impl FloatRound for f64 {
     }
 }
 
-#[cfg(any(feature = "std", feature = "libm"))]
 macro_rules! impl_float {
     ($x:ty: $y:tt) => {
         impl ConvTo<$x, Trunc> for $y {
@@ -143,6 +142,7 @@ macro_rules! impl_float {
             }
         }
 
+        #[cfg(any(feature = "std", feature = "libm"))]
         impl ConvTo<$x, Nearest> for $y {
             type Error = RangeError;
 
@@ -174,6 +174,7 @@ macro_rules! impl_float {
             }
         }
 
+        #[cfg(any(feature = "std", feature = "libm"))]
         impl ConvTo<$x, Floor> for $y {
             type Error = RangeError;
 
@@ -205,6 +206,7 @@ macro_rules! impl_float {
             }
         }
 
+        #[cfg(any(feature = "std", feature = "libm"))]
         impl ConvTo<$x, Ceil> for $y {
             type Error = RangeError;
 
@@ -256,16 +258,11 @@ macro_rules! impl_float {
 }
 
 // Assumption: usize < 128-bit
-#[cfg(any(feature = "std", feature = "libm"))]
 impl_float!(f32: i8, i16, i32, i64, i128, isize);
-#[cfg(any(feature = "std", feature = "libm"))]
 impl_float!(f32: u8, u16, u32, u64, usize);
-#[cfg(any(feature = "std", feature = "libm"))]
 impl_float!(f64: i8, i16, i32, i64, i128, isize);
-#[cfg(any(feature = "std", feature = "libm"))]
 impl_float!(f64: u8, u16, u32, u64, u128, usize);
 
-#[cfg(any(feature = "std", feature = "libm"))]
 impl ConvTo<f32, Trunc> for u128 {
     type Error = RangeError;
 
@@ -360,7 +357,6 @@ impl ConvTo<f32, Ceil> for u128 {
     }
 }
 
-#[cfg(any(feature = "std", feature = "libm"))]
 impl ConvTo<f32, Approx> for u128 {
     type Error = RangeError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!     (rounding mode is implementation-defined just like `as`)
 //! -   Use [`ConvTo`] and [`CastTo`] with an explicit rounding mode
 //!     ([`Trunc`], [`Nearest`], [`Floor`], [`Ceil`]) for conversions with a
-//!     specified rounding mode (requires `std` or `libm` feature)
+//!     specified rounding mode
 //!
 //! ### Error handling
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod impl_basic;
 mod impl_float;

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -50,10 +50,8 @@ impl Rounding for Approx {
 /// Example: `2.9_f32` converts to `2_i32`, `-2.9_f32` converts to `-2_i32`.
 ///
 /// [`as` numeric casts]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.numeric
-#[cfg(any(feature = "std", feature = "libm"))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Trunc;
-#[cfg(any(feature = "std", feature = "libm"))]
 impl Rounding for Trunc {
     type MaximumError = RangeError;
 }

--- a/tests/float_conv.rs
+++ b/tests/float_conv.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "std", feature = "libm"))]
-
 use easy_cast::{RangeError, traits::*};
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -62,7 +62,6 @@ fn f32_max_to_u128() {
 }
 
 #[test]
-#[cfg(any(feature = "std", feature = "libm"))]
 fn approx_float_to_int() {
     assert_eq!(i32::conv_approx(1.99f32), 1);
     assert_eq!(i32::conv_approx(-1.99f32), -1);


### PR DESCRIPTION
It turns out that none of the `Trunc` impls require calling fns like `round()` which are only available on `std` or via `libm`, hence we don't need to feature-gate `Trunc`. This also enables some `Approx` impls which were previously missing without `std` or `libm`.

Note that a couple of `Floor` / `Nearest` impls *could* be written without `std` or `libm`, but I believe discoverability / error messages are sufficient justification to always feature-gate these rounding modes.

Also enables the `doc_cfg` feature for docs.rs.