### PR TITLE
Make `f32::try_conv(u128::MAX)` an error

### DIFF
--- a/src/impl_int.rs
+++ b/src/impl_int.rs
@@ -345,7 +345,7 @@ impl ConvTo<u128, Exact> for f32 {
                 Err(Error::Inexact)
             }
         } else {
-            Ok(f32::INFINITY)
+            Err(Error::Range)
         }
     }
 }

--- a/src/rounding.rs
+++ b/src/rounding.rs
@@ -16,11 +16,15 @@ pub trait Rounding: Copy + Default {
 
 /// Exact conversion only
 ///
-/// Successful conversions using this "rounding" mode must preserve value
+/// Successful conversions using this "rounding" mode must preserve the value
 /// exactly.
 ///
 /// Example: `2.0_f32` may convert to `2_i32`. `2.1_f32` is not convertible to
 /// `i32`.
+///
+/// Another example: `u128::MAX` (which is larger than `f32::MAX`) may not be
+/// converted to `f32` with `Exact` rounding (though with other modes it may
+/// convert to `f32::INFINITY`).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Exact;
 impl Rounding for Exact {

--- a/tests/int_to_float.rs
+++ b/tests/int_to_float.rs
@@ -87,14 +87,19 @@ fn int_to_float_nearest() {
 
 #[test]
 fn int_to_float_overflow() {
-    assert_eq!(
-        f32::try_conv(0xFFFFFF00_00000000_00000000_00000000_u128),
-        Ok(f32::MAX)
-    );
-    assert_eq!(
-        f32::try_conv(0xFFFFFF80_00000000_00000000_00000000_u128),
-        Ok(f32::INFINITY)
-    );
+    // f32::MAX as u128
+    const MAX: u128 = 0xFFFFFF00_00000000_00000000_00000000_u128;
+    // The maximum value approximating to f32::MAX
+    const MAX_APPROX: u128 = 0xFFFFFF7F_FFFFFFFF_FFFFFFFF_FFFFFFFF_u128;
+
+    assert_eq!(f32::try_conv(MAX), Ok(f32::MAX));
+    assert_eq!(f32::try_conv(MAX + 1), Err(Error::Inexact));
+    assert_eq!(f32::try_conv(MAX_APPROX + 1), Ok(f32::INFINITY));
+
+    assert_eq!(f32::try_conv_approx(MAX), Ok(f32::MAX));
+    assert_eq!(f32::try_conv_approx(MAX_APPROX), Ok(f32::MAX));
+    assert_eq!(f32::try_conv_approx(MAX_APPROX + 1), Ok(f32::INFINITY));
+    assert_eq!(f32::try_conv_approx(u128::MAX), Ok(f32::INFINITY));
 }
 
 #[test]

--- a/tests/int_to_float.rs
+++ b/tests/int_to_float.rs
@@ -94,7 +94,7 @@ fn int_to_float_overflow() {
 
     assert_eq!(f32::try_conv(MAX), Ok(f32::MAX));
     assert_eq!(f32::try_conv(MAX + 1), Err(Error::Inexact));
-    assert_eq!(f32::try_conv(MAX_APPROX + 1), Ok(f32::INFINITY));
+    assert_eq!(f32::try_conv(MAX_APPROX + 1), Err(Error::Range));
 
     assert_eq!(f32::try_conv_approx(MAX), Ok(f32::MAX));
     assert_eq!(f32::try_conv_approx(MAX_APPROX), Ok(f32::MAX));


### PR DESCRIPTION
This is a corner case; previously `f32::try_conv(u128::MAX)` would result in `Ok(f32::INFINITY)`. Since we now require `Exact` "rounding" by default this is no longer permitted. (With the `Approx` and `Nearest` rounding modes `u128::MAX` still converts to `f32::INFINITY`).