### PR TITLE
Rename `impl_via_trivial!` → `impl_via_identity!`

### DIFF
--- a/src/impl_basic.rs
+++ b/src/impl_basic.rs
@@ -8,6 +8,50 @@
 use crate::{ConvTo, Rounding};
 use core::convert::Infallible;
 
+/// Implement an identity "conversion" via [`ConvExact`] infallibly
+///
+/// Note: [`ConvExact`] is not inherently reflexive (there is no
+/// `impl<T> ConvExact<T> for T`) since this would conflict with some other
+/// required impls. Use this instead.
+///
+/// # Example
+///
+/// ```
+/// struct MyInt(i32);
+///
+/// easy_cast::impl_via_identity!(MyInt);
+/// ```
+///
+/// [`ConvExact`]: crate::ConvExact
+#[macro_export]
+macro_rules! impl_via_identity {
+    ($x:ty) => {
+        impl $crate::ConvExact<$x> for $x {
+            type Error = ::core::convert::Infallible;
+
+            #[inline]
+            fn conv_exact(x: $x) -> Self {
+                x
+            }
+            #[inline]
+            fn try_conv_exact(x: $x) -> Result<Self, Self::Error> {
+                Ok(x)
+            }
+        }
+    };
+    ($x:ty $(, $xx:tt)* $(,)?) => {
+        $crate::impl_via_identity!($x);
+        $crate::impl_via_identity!($($xx),*);
+    };
+}
+
+#[rustfmt::skip]
+impl_via_identity!(
+    u8, u16, u32, u64, u128, usize,
+    i8, i16, i32, i64, i128, isize,
+    f32, f64,
+);
+
 /// Implement [`ConvExact`] infallibly over a [`From`] implementation
 ///
 /// # Example
@@ -252,45 +296,3 @@ where
         )
     }
 }
-
-/// Implement a trivial [`ConvExact`] infallibly
-///
-/// A trivial conversion is one which maps a type to itself.
-///
-/// # Example
-///
-/// ```
-/// struct MyInt(i32);
-///
-/// easy_cast::impl_via_trivial!(MyInt);
-/// ```
-///
-/// [`ConvExact`]: crate::ConvExact
-#[macro_export]
-macro_rules! impl_via_trivial {
-    ($x:ty) => {
-        impl $crate::ConvExact<$x> for $x {
-            type Error = ::core::convert::Infallible;
-
-            #[inline]
-            fn conv_exact(x: $x) -> Self {
-                x
-            }
-            #[inline]
-            fn try_conv_exact(x: $x) -> Result<Self, Self::Error> {
-                Ok(x)
-            }
-        }
-    };
-    ($x:ty $(, $xx:tt)* $(,)?) => {
-        $crate::impl_via_trivial!($x);
-        $crate::impl_via_trivial!($($xx),*);
-    };
-}
-
-#[rustfmt::skip]
-impl_via_trivial!(
-    u8, u16, u32, u64, u128, usize,
-    i8, i16, i32, i64, i128, isize,
-    f32, f64,
-);

--- a/src/impl_float.rs
+++ b/src/impl_float.rs
@@ -77,6 +77,15 @@ impl ConvTo<f64, Exact> for f32 {
             true => Err(Error::Range),
         }
     }
+
+    #[inline]
+    fn conv_to(_: Exact, x: f64) -> f32 {
+        if cfg!(any(debug_assertions, feature = "assert_float")) {
+            f32::try_conv_to(Exact, x).unwrap_or_else(|e| panic!("cast float-to-float: {e}"))
+        } else {
+            x as f32
+        }
+    }
 }
 
 #[cfg(all(not(feature = "std"), feature = "libm"))]

--- a/src/impl_num.rs
+++ b/src/impl_num.rs
@@ -5,36 +5,19 @@
 
 //! `core::num` impls.
 
-use crate::{ConvExact, RangeError};
-use core::convert::Infallible;
+use crate::{ConvExact, RangeError, impl_via_identity};
 use core::num::NonZero;
 
-macro_rules! impl_via_trivial {
-    ($x:ty) => {
-        impl ConvExact<NonZero<$x>> for NonZero<$x> {
-            type Error = Infallible;
-
-            #[inline]
-            fn conv_exact(x: NonZero<$x>) -> Self {
-                x
-            }
-            #[inline]
-            fn try_conv_exact(x: NonZero<$x>) -> Result<Self, Infallible> {
-                Ok(x)
-            }
-        }
-    };
-    ($x:ty $(, $xx:tt)* $(,)?) => {
-        impl_via_trivial!($x);
-        impl_via_trivial!($($xx),*);
+macro_rules! impl_identity {
+    ($($x:tt),*) => {
+        $(
+            impl_via_identity!(NonZero<$x>);
+        )*
     };
 }
 
-#[rustfmt::skip]
-impl_via_trivial!(
-    u8, u16, u32, u64, u128, usize,
-    i8, i16, i32, i64, i128, isize,
-);
+impl_identity!(u8, u16, u32, u64, u128, usize);
+impl_identity!(i8, i16, i32, i64, i128, isize);
 
 macro_rules! impl_nonzero {
     ($x:ty : $y:ty) => {


### PR DESCRIPTION
Renames `impl_via_trivial!` → `impl_via_identity!` (breaking; added last week in 0.6.1).

Also and adds a missing `conv_to` impl (optimisation).