### PR TITLE
Note on work-around for float_conversions feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## [0.7.1] — 2026-08-28
+
+Added:
+
+-   Note on work-around to fn `Cast::cast`, usage of which may conflict with the unstable `float_conversions` feature (#71)
+
 ## [0.7.0] — 2026-08-05
 
 This version is a substantial revision of `easy-cast`, introducing generics over rounding modes via the new `Rounding` trait.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-cast"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Diggory Hardy <git@dhardy.name>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -166,6 +166,11 @@ pub trait Cast<T> {
     ///
     /// Use this method only when success is expected. On error, this method may
     /// panic or may exhibit [§ Fallback behaviour](crate#fallback-behaviour).
+    ///
+    /// Note: the unstable `float_conversions` feature adds an inherent `cast`
+    /// method to float types which in some cases will conflict with usage of
+    /// this method. We recommend using `Cast::cast(x)` instead of `x.cast()`
+    /// as a work-around until this feature stabilizes.
     fn cast(self) -> T;
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -82,6 +82,9 @@ fn float_casts() {
     assert_eq!(u8::conv_to(Floor, 13.8f64), 13);
     assert_eq!(u32::conv_to(Ceil, 13.1f32), 14);
     assert_eq!(i64::conv_to(Floor, -3168565.13f64), -3168566);
+
+    let x: f32 = Cast::cast(1.5f64);
+    assert_eq!(x, 1.5f32);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,7 +15,7 @@ fn int_casts() {
 fn signed_to_unsigned() {
     u32::conv(0i32);
     u32::conv(1i32);
-    u32::conv(core::i32::MAX);
+    u32::conv(i32::MAX);
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn float_trunc_fail1() {
 #[test]
 #[should_panic(expected = "cast x: u32 to f32: inexact for x = 4294967295")]
 fn u32_max_f32() {
-    f32::conv(core::u32::MAX);
+    f32::conv(u32::MAX);
 }
 
 #[test]


### PR DESCRIPTION
Summary: recommend `Cast::cast(x)` where `x.cast()` triggers a warning of conflict with `float_conversions` feature.

Rationale: this is a minimum-commitment workaround for a conflict with an unstable (and thus uncertain) feature. If the feature lands (especially the additional int→int casts), we should reconsider (e.g. renaming `cast` or abandoning the library as obsolete — though currently the unstable `std` lib additions lack trait methods which renders them an incomplete replacement).